### PR TITLE
Require active_support before active_support/core_ext

### DIFF
--- a/lib/hubspot-ruby.rb
+++ b/lib/hubspot-ruby.rb
@@ -1,3 +1,4 @@
+require 'active_support'
 require 'active_support/core_ext'
 require 'httparty'
 require 'hubspot/exceptions'


### PR DESCRIPTION
Was getting the following error.  Followed advice from similar issue (https://github.com/huydx/facy/issues/17) to fix.

```
irb(main):001:0> require 'hubspot-ruby'
NameError: uninitialized constant ActiveSupport::Autoload
	from /usr/local/bundle/gems/activesupport-4.2.2/lib/active_support/number_helper.rb:3:in `<module:NumberHelper>'
	from /usr/local/bundle/gems/activesupport-4.2.2/lib/active_support/number_helper.rb:2:in `<module:ActiveSupport>'
	from /usr/local/bundle/gems/activesupport-4.2.2/lib/active_support/number_helper.rb:1:in `<top (required)>'
...
```
