### PR TITLE
changed Hubspot::Topic to use v3 api

### DIFF
--- a/lib/hubspot/topic.rb
+++ b/lib/hubspot/topic.rb
@@ -3,8 +3,8 @@ module Hubspot
   # HubSpot Topics API
   #
   class Topic
-    TOPICS_PATH = "/content/api/v2/topics"
-    TOPIC_PATH = "/content/api/v2/topics/:topic_id"
+    TOPICS_PATH = "/blogs/v3/topics"
+    TOPIC_PATH = "/blogs/v3/topics/:topic_id"
 
     class << self
       # Lists the topics

--- a/spec/fixtures/vcr_cassettes/topic_list.yml
+++ b/spec/fixtures/vcr_cassettes/topic_list.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.hubapi.com/content/api/v2/topics?hapikey=demo
+    uri: https://api.hubapi.com/blogs/v3/topics?hapikey=demo
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/topics_list.yml
+++ b/spec/fixtures/vcr_cassettes/topics_list.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.hubapi.com/content/api/v2/topics?hapikey=demo
+    uri: https://api.hubapi.com/blogs/v3/topics?hapikey=demo
     body:
       encoding: US-ASCII
       string: ''
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Mon, 20 Oct 2014 02:55:54 GMT
 - request:
     method: get
-    uri: https://api.hubapi.com/content/api/v2/topics/349001328?hapikey=demo
+    uri: https://api.hubapi.com/blogs/v3/topics/349001328?hapikey=demo
     body:
       encoding: US-ASCII
       string: ''


### PR DESCRIPTION
Hubspot depreciated v2 of Blog Topics API today 7/21

Fixes this issue
https://github.com/adimichele/hubspot-ruby/issues/21