### PR TITLE
URI encode query parameters

### DIFF
--- a/lib/hubspot/connection.rb
+++ b/lib/hubspot/connection.rb
@@ -58,7 +58,7 @@ module Hubspot
 
         params.each do |k,v|
           if path.match(":#{k}")
-            path.gsub!(":#{k}",v.to_s)
+            path.gsub!(":#{k}", CGI.escape(v.to_s))
             params.delete(k)
           end
         end
@@ -74,7 +74,7 @@ module Hubspot
 
       # convert into milliseconds since epoch
       def converted_value(value)
-        value.is_a?(Time) ? (value.to_i * 1000) : value
+        value.is_a?(Time) ? (value.to_i * 1000) : CGI.escape(value.to_s)
       end
 
       def param_string(key,value)

--- a/spec/lib/hubspot/connection_spec.rb
+++ b/spec/lib/hubspot/connection_spec.rb
@@ -76,30 +76,36 @@ describe Hubspot::Connection do
 
       context "with an interpolated param" do
         let(:params){ {email: "email@address.com"} }
-        it{ should == "https://api.hubapi.com/test/email@address.com/profile?hapikey=demo" }
+        it{ should == "https://api.hubapi.com/test/email%40address.com/profile?hapikey=demo" }
       end
 
       context "with multiple interpolated params" do
         let(:path){ "/test/:email/:id/profile" }
         let(:params){{email: "email@address.com", id: 1234}}
-        it{ should == "https://api.hubapi.com/test/email@address.com/1234/profile?hapikey=demo" }
+        it{ should == "https://api.hubapi.com/test/email%40address.com/1234/profile?hapikey=demo" }
       end
 
       context "with query params" do
         let(:params){{email: "email@address.com", id: 1234}}
-        it{ should == "https://api.hubapi.com/test/email@address.com/profile?id=1234&hapikey=demo" }
+        it{ should == "https://api.hubapi.com/test/email%40address.com/profile?id=1234&hapikey=demo" }
 
         context "containing a time" do
           let(:start_time) { Time.now }
           let(:params){{email: "email@address.com", id: 1234, start: start_time}}
-          it{ should == "https://api.hubapi.com/test/email@address.com/profile?id=1234&start=#{start_time.to_i * 1000}&hapikey=demo" }
+          it{ should == "https://api.hubapi.com/test/email%40address.com/profile?id=1234&start=#{start_time.to_i * 1000}&hapikey=demo" }
         end
 
         context "containing a range" do
           let(:start_time) { Time.now }
           let(:end_time) { Time.now + 1.year }
           let(:params){{email: "email@address.com", id: 1234, created__range: start_time..end_time }}
-          it{ should == "https://api.hubapi.com/test/email@address.com/profile?id=1234&created__range=#{start_time.to_i * 1000}&created__range=#{end_time.to_i * 1000}&hapikey=demo" }
+          it{ should == "https://api.hubapi.com/test/email%40address.com/profile?id=1234&created__range=#{start_time.to_i * 1000}&created__range=#{end_time.to_i * 1000}&hapikey=demo" }
+        end
+
+        context "containing an array of strings" do
+          let(:path){ "/test/emails" }
+          let(:params){{batch_email: %w(email1@example.com email2@example.com)}}
+          it{ should == "https://api.hubapi.com/test/emails?email=email1%40example.com&email=email2%40example.com&hapikey=demo" }
         end
       end
 


### PR DESCRIPTION
When query parameters contain special characters, call to server fails with the following error:

```
URI::InvalidURIError: bad URI(is not URI?):
```

To fix this, we need to properly encode and escape special characters for outgoing query parameters and paths.
