### PR TITLE
Add support for Engagements and Engagement Notes

### DIFF
--- a/lib/hubspot-ruby.rb
+++ b/lib/hubspot-ruby.rb
@@ -16,6 +16,7 @@ require 'hubspot/deal'
 require 'hubspot/deal_pipeline'
 require 'hubspot/deal_properties'
 require 'hubspot/owner'
+require 'hubspot/engagement'
 
 module Hubspot
   def self.configure(config={})

--- a/lib/hubspot/engagement.rb
+++ b/lib/hubspot/engagement.rb
@@ -59,10 +59,10 @@ module Hubspot
       @properties[property]
     end
 
-    # Updates the properties of a deal
+    # Updates the properties of an engagement
     # {http://developers.hubspot.com/docs/methods/engagements/update_engagement}
     # @param params [Hash] hash of properties to update
-    # @return [Hubspot::Deal] self
+    # @return [Hubspot::Engagement] self
     def update!(params)
       data = {
         engagement: engagement,

--- a/lib/hubspot/engagement.rb
+++ b/lib/hubspot/engagement.rb
@@ -1,0 +1,108 @@
+require 'hubspot/utils'
+
+module Hubspot
+  #
+  # HubSpot Engagements API
+  #
+  # {http://developers.hubspot.com/docs/methods/engagements/create_engagement}
+  #
+  class Engagement
+    CREATE_ENGAGMEMENT_PATH = '/engagements/v1/engagements'
+    ENGAGEMENT_PATH = '/engagements/v1/engagements/:engagement_id'
+
+    attr_reader :id
+    attr_reader :engagement
+    attr_reader :associations
+    attr_reader :metadata
+
+    def initialize(response_hash)
+
+      @engagement = response_hash["engagement"]
+      @associations = response_hash["associations"]
+      @metadata = response_hash["metadata"]
+      @id = engagement["id"]
+    end
+
+    class << self
+      def create!(params={})
+        response = Hubspot::Connection.post_json(CREATE_ENGAGMEMENT_PATH, params: {}, body: params )
+        new(HashWithIndifferentAccess.new(response))
+      end
+
+      def find(engagement_id)
+        begin
+          response = Hubspot::Connection.get_json(ENGAGEMENT_PATH, { engagement_id: engagement_id })
+          new(HashWithIndifferentAccess.new(response))
+        rescue Hubspot::RequestError => ex
+          if ex.response.code == 404
+            return nil
+          else
+            raise ex
+          end
+        end
+      end
+    end
+
+    # Archives the engagement in hubspot
+    # {http://developers.hubspot.com/docs/methods/engagements/delete-engagement}
+    # @return [TrueClass] true
+    def destroy!
+      response = Hubspot::Connection.delete_json(ENGAGEMENT_PATH, {engagement_id: id})
+      @destroyed = true
+    end
+
+    def destroyed?
+      !!@destroyed
+    end
+
+    def [](property)
+      @properties[property]
+    end
+
+    # Updates the properties of a deal
+    # {http://developers.hubspot.com/docs/methods/engagements/update_engagement}
+    # @param params [Hash] hash of properties to update
+    # @return [Hubspot::Deal] self
+    def update!(params)
+      data = {
+        engagement: engagement,
+        associations: associations,
+        metadata: metadata
+      }
+
+      response = Hubspot::Connection.put_json(ENGAGEMENT_PATH, params: { engagement_id: id }, body: data)
+      self
+    end
+  end
+
+  class EngagementNote < Engagement
+    def body
+      metadata['body']
+    end
+
+    def contact_ids
+      associations['contactIds']
+    end
+
+    class << self
+      def create!(contact_id, note_body, owner_id = nil)
+        data = {
+          engagement: {
+            type: 'NOTE'
+          },
+          associations: {
+            contactIds: [contact_id]
+          },
+          metadata: {
+            body: note_body
+          }
+        }
+
+        # if the owner id has been provided, append it to the engagement
+        data[:engagement][:owner_id] = owner_id if owner_id
+
+        super(data)
+      end
+    end
+  end
+end

--- a/spec/fixtures/vcr_cassettes/contact_create_or_update.yml
+++ b/spec/fixtures/vcr_cassettes/contact_create_or_update.yml
@@ -248,4 +248,252 @@ http_interactions:
       string: '{"vid":1922324,"canonical-vid":1922324,"merged-vids":[],"portal-id":62515,"is-contact":true,"profile-token":"AO_T-mMUW4ngofcA4uoQGmqBE_ozg4LabC9D50upKQ70oiWSSZFuKdNnSJ2-pifDI7mHVdKrPejGashPeTe4OIwRTqItR-94rPDVcz7ZL_pjAzbz5nDv7OtyGDsLQSn7v03r9CXGp7Bx","profile-url":"https://app.hubspot.com/contacts/62515/lists/public/contact/_AO_T-mMUW4ngofcA4uoQGmqBE_ozg4LabC9D50upKQ70oiWSSZFuKdNnSJ2-pifDI7mHVdKrPejGashPeTe4OIwRTqItR-94rPDVcz7ZL_pjAzbz5nDv7OtyGDsLQSn7v03r9CXGp7Bx/","properties":{"lastmodifieddate":{"value":"1466963483050","versions":[{"value":"1466963483050","source-type":"CALCULATED","source-id":null,"source-label":null,"timestamp":1466963483050,"selected":false}]},"num_conversion_events":{"value":"0","versions":[{"value":"0","source-type":"CALCULATED","source-id":null,"source-label":null,"timestamp":0,"selected":false}]},"num_unique_conversion_events":{"value":"0","versions":[{"value":"0","source-type":"CALCULATED","source-id":null,"source-label":null,"timestamp":0,"selected":false}]},"createdate":{"value":"1466963482967","versions":[{"value":"1466963482967","source-type":"API","source-id":"contact-upsert","source-label":null,"timestamp":1466963482967,"selected":false}]},"hs_lifecyclestage_subscriber_date":{"value":"1466963482967","versions":[{"value":"1466963482967","source-type":"API","source-id":null,"source-label":null,"timestamp":1466963482967,"selected":false}]},"lifecyclestage":{"value":"subscriber","versions":[{"value":"subscriber","source-type":"API","source-id":null,"source-label":null,"timestamp":1466963482967,"selected":false}]},"email":{"value":"newcontact1466963484@hsgem.com","versions":[{"value":"newcontact1466963484@hsgem.com","source-type":"API","source-id":"contact-upsert","source-label":null,"timestamp":1466963482967,"selected":false}]}},"form-submissions":[],"list-memberships":[],"identity-profiles":[{"vid":1922324,"saved-at-timestamp":1466963482977,"deleted-changed-timestamp":0,"identities":[{"type":"EMAIL","value":"newcontact1466963484@hsgem.com","timestamp":1466963482967},{"type":"LEAD_GUID","value":"e55f4f44-3747-4675-acff-16cf6f086d27","timestamp":1466963482971}]}],"merge-audits":[]}'
     http_version: 
   recorded_at: Sun, 26 Jun 2016 17:51:24 GMT
+- request:
+    method: post
+    uri: https://api.hubapi.com/contacts/v1/contact/createOrUpdate/email/newcontact1467152214@hsgem.com?hapikey=demo
+    body:
+      encoding: UTF-8
+      string: '{"properties":[]}'
+    headers:
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      Content-Length:
+      - '28'
+      Date:
+      - Tue, 28 Jun 2016 22:16:55 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"vid":1953874,"isNew":true}'
+    http_version: 
+  recorded_at: Tue, 28 Jun 2016 22:16:55 GMT
+- request:
+    method: get
+    uri: https://api.hubapi.com/contacts/v1/contact/vid/1953874/profile?hapikey=demo
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers: {}
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      Content-Length:
+      - '2147'
+      Date:
+      - Tue, 28 Jun 2016 22:16:55 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"vid":1953874,"canonical-vid":1953874,"merged-vids":[],"portal-id":62515,"is-contact":true,"profile-token":"AO_T-mMZWw0RPp1vR5S8FYXepM4LOVWg6j-hjF751wZ5qixKFuubdKh6QKE7KRmLWugw1riOs-itx0u_L3rOH39ihzeZwXIn5lRoPTXVbWEUp3ArIQYjI1NpJPX72dgqm9ShVob98MWB","profile-url":"https://app.hubspot.com/contacts/62515/lists/public/contact/_AO_T-mMZWw0RPp1vR5S8FYXepM4LOVWg6j-hjF751wZ5qixKFuubdKh6QKE7KRmLWugw1riOs-itx0u_L3rOH39ihzeZwXIn5lRoPTXVbWEUp3ArIQYjI1NpJPX72dgqm9ShVob98MWB/","properties":{"lastmodifieddate":{"value":"1467152215537","versions":[{"value":"1467152215537","source-type":"CALCULATED","source-id":null,"source-label":null,"timestamp":1467152215537,"selected":false}]},"num_conversion_events":{"value":"0","versions":[{"value":"0","source-type":"CALCULATED","source-id":null,"source-label":null,"timestamp":0,"selected":false}]},"num_unique_conversion_events":{"value":"0","versions":[{"value":"0","source-type":"CALCULATED","source-id":null,"source-label":null,"timestamp":0,"selected":false}]},"createdate":{"value":"1467152215454","versions":[{"value":"1467152215454","source-type":"API","source-id":"contact-upsert","source-label":null,"timestamp":1467152215454,"selected":false}]},"hs_lifecyclestage_subscriber_date":{"value":"1467152215454","versions":[{"value":"1467152215454","source-type":"API","source-id":null,"source-label":null,"timestamp":1467152215454,"selected":false}]},"lifecyclestage":{"value":"subscriber","versions":[{"value":"subscriber","source-type":"API","source-id":null,"source-label":null,"timestamp":1467152215454,"selected":false}]},"email":{"value":"newcontact1467152214@hsgem.com","versions":[{"value":"newcontact1467152214@hsgem.com","source-type":"API","source-id":"contact-upsert","source-label":null,"timestamp":1467152215454,"selected":false}]}},"form-submissions":[],"list-memberships":[],"identity-profiles":[{"vid":1953874,"saved-at-timestamp":1467152215463,"deleted-changed-timestamp":0,"identities":[{"type":"EMAIL","value":"newcontact1467152214@hsgem.com","timestamp":1467152215454},{"type":"LEAD_GUID","value":"f7f04950-d140-4382-b42e-e18fc8874f58","timestamp":1467152215459}]}],"merge-audits":[]}'
+    http_version: 
+  recorded_at: Tue, 28 Jun 2016 22:16:55 GMT
+- request:
+    method: post
+    uri: https://api.hubapi.com/contacts/v1/contact/createOrUpdate/email/newcontact1467152215@hsgem.com?hapikey=demo
+    body:
+      encoding: UTF-8
+      string: '{"properties":[]}'
+    headers:
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      Content-Length:
+      - '28'
+      Date:
+      - Tue, 28 Jun 2016 22:16:55 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"vid":1953924,"isNew":true}'
+    http_version: 
+  recorded_at: Tue, 28 Jun 2016 22:16:55 GMT
+- request:
+    method: get
+    uri: https://api.hubapi.com/contacts/v1/contact/vid/1953924/profile?hapikey=demo
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers: {}
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      Content-Length:
+      - '2147'
+      Date:
+      - Tue, 28 Jun 2016 22:16:56 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"vid":1953924,"canonical-vid":1953924,"merged-vids":[],"portal-id":62515,"is-contact":true,"profile-token":"AO_T-mMWWd3UuFmvlyPUb8Cvc4RQskyHoXQFU9yz5QoPInXDRp6qYJ5qD-uvyjJ7eYmo2jvpnexBoMK7JgUIitpePMufnxEXte2J01LjcL7SDUwOUL5Bzh2lXBazI20BZ2YBQmHgYWPp","profile-url":"https://app.hubspot.com/contacts/62515/lists/public/contact/_AO_T-mMWWd3UuFmvlyPUb8Cvc4RQskyHoXQFU9yz5QoPInXDRp6qYJ5qD-uvyjJ7eYmo2jvpnexBoMK7JgUIitpePMufnxEXte2J01LjcL7SDUwOUL5Bzh2lXBazI20BZ2YBQmHgYWPp/","properties":{"lastmodifieddate":{"value":"1467152215865","versions":[{"value":"1467152215865","source-type":"CALCULATED","source-id":null,"source-label":null,"timestamp":1467152215865,"selected":false}]},"num_conversion_events":{"value":"0","versions":[{"value":"0","source-type":"CALCULATED","source-id":null,"source-label":null,"timestamp":0,"selected":false}]},"num_unique_conversion_events":{"value":"0","versions":[{"value":"0","source-type":"CALCULATED","source-id":null,"source-label":null,"timestamp":0,"selected":false}]},"createdate":{"value":"1467152215805","versions":[{"value":"1467152215805","source-type":"API","source-id":"contact-upsert","source-label":null,"timestamp":1467152215805,"selected":false}]},"hs_lifecyclestage_subscriber_date":{"value":"1467152215805","versions":[{"value":"1467152215805","source-type":"API","source-id":null,"source-label":null,"timestamp":1467152215805,"selected":false}]},"lifecyclestage":{"value":"subscriber","versions":[{"value":"subscriber","source-type":"API","source-id":null,"source-label":null,"timestamp":1467152215805,"selected":false}]},"email":{"value":"newcontact1467152215@hsgem.com","versions":[{"value":"newcontact1467152215@hsgem.com","source-type":"API","source-id":"contact-upsert","source-label":null,"timestamp":1467152215805,"selected":false}]}},"form-submissions":[],"list-memberships":[],"identity-profiles":[{"vid":1953924,"saved-at-timestamp":1467152215809,"deleted-changed-timestamp":0,"identities":[{"type":"EMAIL","value":"newcontact1467152215@hsgem.com","timestamp":1467152215805},{"type":"LEAD_GUID","value":"5a1d4b50-6774-492e-bdf2-18fdf9fdd4a7","timestamp":1467152215806}]}],"merge-audits":[]}'
+    http_version: 
+  recorded_at: Tue, 28 Jun 2016 22:16:55 GMT
+- request:
+    method: post
+    uri: https://api.hubapi.com/contacts/v1/contact/createOrUpdate/email/newcontact1467152872@hsgem.com?hapikey=demo
+    body:
+      encoding: UTF-8
+      string: '{"properties":[]}'
+    headers:
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      Content-Length:
+      - '28'
+      Date:
+      - Tue, 28 Jun 2016 22:27:53 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"vid":1954024,"isNew":true}'
+    http_version: 
+  recorded_at: Tue, 28 Jun 2016 22:27:53 GMT
+- request:
+    method: get
+    uri: https://api.hubapi.com/contacts/v1/contact/vid/1954024/profile?hapikey=demo
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers: {}
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      Content-Length:
+      - '2147'
+      Date:
+      - Tue, 28 Jun 2016 22:27:53 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"vid":1954024,"canonical-vid":1954024,"merged-vids":[],"portal-id":62515,"is-contact":true,"profile-token":"AO_T-mP2h9e9-nhHiQGiC_Bec2DQr8rK9xnhJ1OBsbQrbSCFZS6EsDlZZx3vIo0QJdMicbHyaD-JTOt-CdTmnQfkdd9CHgrfC_f_xWYauVhe1_SZQilckhrdzlI3WQpVy3jOS_WwGAxE","profile-url":"https://app.hubspot.com/contacts/62515/lists/public/contact/_AO_T-mP2h9e9-nhHiQGiC_Bec2DQr8rK9xnhJ1OBsbQrbSCFZS6EsDlZZx3vIo0QJdMicbHyaD-JTOt-CdTmnQfkdd9CHgrfC_f_xWYauVhe1_SZQilckhrdzlI3WQpVy3jOS_WwGAxE/","properties":{"lastmodifieddate":{"value":"1467152873145","versions":[{"value":"1467152873145","source-type":"CALCULATED","source-id":null,"source-label":null,"timestamp":1467152873145,"selected":false}]},"num_conversion_events":{"value":"0","versions":[{"value":"0","source-type":"CALCULATED","source-id":null,"source-label":null,"timestamp":0,"selected":false}]},"num_unique_conversion_events":{"value":"0","versions":[{"value":"0","source-type":"CALCULATED","source-id":null,"source-label":null,"timestamp":0,"selected":false}]},"createdate":{"value":"1467152872903","versions":[{"value":"1467152872903","source-type":"API","source-id":"contact-upsert","source-label":null,"timestamp":1467152872903,"selected":false}]},"hs_lifecyclestage_subscriber_date":{"value":"1467152872903","versions":[{"value":"1467152872903","source-type":"API","source-id":null,"source-label":null,"timestamp":1467152872903,"selected":false}]},"lifecyclestage":{"value":"subscriber","versions":[{"value":"subscriber","source-type":"API","source-id":null,"source-label":null,"timestamp":1467152872903,"selected":false}]},"email":{"value":"newcontact1467152872@hsgem.com","versions":[{"value":"newcontact1467152872@hsgem.com","source-type":"API","source-id":"contact-upsert","source-label":null,"timestamp":1467152872903,"selected":false}]}},"form-submissions":[],"list-memberships":[],"identity-profiles":[{"vid":1954024,"saved-at-timestamp":1467152872908,"deleted-changed-timestamp":0,"identities":[{"type":"EMAIL","value":"newcontact1467152872@hsgem.com","timestamp":1467152872903},{"type":"LEAD_GUID","value":"102c26ea-84b0-4a53-9a71-0ff068127226","timestamp":1467152872905}]}],"merge-audits":[]}'
+    http_version: 
+  recorded_at: Tue, 28 Jun 2016 22:27:53 GMT
+- request:
+    method: post
+    uri: https://api.hubapi.com/contacts/v1/contact/createOrUpdate/email/newcontact1467152873@hsgem.com?hapikey=demo
+    body:
+      encoding: UTF-8
+      string: '{"properties":[]}'
+    headers:
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      Content-Length:
+      - '28'
+      Date:
+      - Tue, 28 Jun 2016 22:27:54 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"vid":1954074,"isNew":true}'
+    http_version: 
+  recorded_at: Tue, 28 Jun 2016 22:27:54 GMT
+- request:
+    method: get
+    uri: https://api.hubapi.com/contacts/v1/contact/vid/1954074/profile?hapikey=demo
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers: {}
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      Content-Length:
+      - '2147'
+      Date:
+      - Tue, 28 Jun 2016 22:27:54 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"vid":1954074,"canonical-vid":1954074,"merged-vids":[],"portal-id":62515,"is-contact":true,"profile-token":"AO_T-mMBUFa5Iw_Ce91slcZEjsWCjISPrRWeB15BRC1SttGnytzeuYcxyclNmuBQGkbETxeULUS9X3NRiN_I15a33aN_jo69vSJvysrPefQHoCT6SCHFTbdusHtvSwvJTR5vf7Lh6kEi","profile-url":"https://app.hubspot.com/contacts/62515/lists/public/contact/_AO_T-mMBUFa5Iw_Ce91slcZEjsWCjISPrRWeB15BRC1SttGnytzeuYcxyclNmuBQGkbETxeULUS9X3NRiN_I15a33aN_jo69vSJvysrPefQHoCT6SCHFTbdusHtvSwvJTR5vf7Lh6kEi/","properties":{"lastmodifieddate":{"value":"1467152874140","versions":[{"value":"1467152874140","source-type":"CALCULATED","source-id":null,"source-label":null,"timestamp":1467152874140,"selected":false}]},"num_conversion_events":{"value":"0","versions":[{"value":"0","source-type":"CALCULATED","source-id":null,"source-label":null,"timestamp":0,"selected":false}]},"num_unique_conversion_events":{"value":"0","versions":[{"value":"0","source-type":"CALCULATED","source-id":null,"source-label":null,"timestamp":0,"selected":false}]},"createdate":{"value":"1467152873809","versions":[{"value":"1467152873809","source-type":"API","source-id":"contact-upsert","source-label":null,"timestamp":1467152873809,"selected":false}]},"hs_lifecyclestage_subscriber_date":{"value":"1467152873809","versions":[{"value":"1467152873809","source-type":"API","source-id":null,"source-label":null,"timestamp":1467152873809,"selected":false}]},"lifecyclestage":{"value":"subscriber","versions":[{"value":"subscriber","source-type":"API","source-id":null,"source-label":null,"timestamp":1467152873809,"selected":false}]},"email":{"value":"newcontact1467152873@hsgem.com","versions":[{"value":"newcontact1467152873@hsgem.com","source-type":"API","source-id":"contact-upsert","source-label":null,"timestamp":1467152873809,"selected":false}]}},"form-submissions":[],"list-memberships":[],"identity-profiles":[{"vid":1954074,"saved-at-timestamp":1467152873821,"deleted-changed-timestamp":0,"identities":[{"type":"EMAIL","value":"newcontact1467152873@hsgem.com","timestamp":1467152873809},{"type":"LEAD_GUID","value":"1e68091a-bb30-4405-92e5-b40e454df9a2","timestamp":1467152873817}]}],"merge-audits":[]}'
+    http_version: 
+  recorded_at: Tue, 28 Jun 2016 22:27:54 GMT
 recorded_with: VCR 2.4.0

--- a/spec/fixtures/vcr_cassettes/contact_create_or_update_with_params.yml
+++ b/spec/fixtures/vcr_cassettes/contact_create_or_update_with_params.yml
@@ -248,4 +248,252 @@ http_interactions:
       string: '{"vid":1922325,"canonical-vid":1922325,"merged-vids":[],"portal-id":62515,"is-contact":true,"profile-token":"AO_T-mNoGb9PKaVeKTB37FESZZJA_M26_o0z9dkm2ACZPCIjjGS256u-A_5Gx_p926YghWFTR19ieUu3ugSB59f_IT5puqLQzgunFBs5lUYtiLDBAxnO-L3r0iwLF8vyVhauw-R5ujkw","profile-url":"https://app.hubspot.com/contacts/62515/lists/public/contact/_AO_T-mNoGb9PKaVeKTB37FESZZJA_M26_o0z9dkm2ACZPCIjjGS256u-A_5Gx_p926YghWFTR19ieUu3ugSB59f_IT5puqLQzgunFBs5lUYtiLDBAxnO-L3r0iwLF8vyVhauw-R5ujkw/","properties":{"firstname":{"value":"Hugh","versions":[{"value":"Hugh","source-type":"API","source-id":null,"source-label":null,"timestamp":1466963483626,"selected":false}]},"lastmodifieddate":{"value":"1466963483720","versions":[{"value":"1466963483720","source-type":"CALCULATED","source-id":null,"source-label":null,"timestamp":1466963483720,"selected":false}]},"num_conversion_events":{"value":"0","versions":[{"value":"0","source-type":"CALCULATED","source-id":null,"source-label":null,"timestamp":0,"selected":false}]},"num_unique_conversion_events":{"value":"0","versions":[{"value":"0","source-type":"CALCULATED","source-id":null,"source-label":null,"timestamp":0,"selected":false}]},"createdate":{"value":"1466963483646","versions":[{"value":"1466963483646","source-type":"API","source-id":"contact-upsert","source-label":null,"timestamp":1466963483646,"selected":false}]},"hs_lifecyclestage_subscriber_date":{"value":"1466963483646","versions":[{"value":"1466963483646","source-type":"API","source-id":null,"source-label":null,"timestamp":1466963483646,"selected":false}]},"lifecyclestage":{"value":"subscriber","versions":[{"value":"subscriber","source-type":"API","source-id":null,"source-label":null,"timestamp":1466963483646,"selected":false}]},"email":{"value":"newcontact_x_1466963485@hsgem.com","versions":[{"value":"newcontact_x_1466963485@hsgem.com","source-type":"API","source-id":"contact-upsert","source-label":null,"timestamp":1466963483646,"selected":false}]},"lastname":{"value":"Jackman","versions":[{"value":"Jackman","source-type":"API","source-id":null,"source-label":null,"timestamp":1466963483626,"selected":false}]}},"form-submissions":[],"list-memberships":[],"identity-profiles":[{"vid":1922325,"saved-at-timestamp":1466963483651,"deleted-changed-timestamp":0,"identities":[{"type":"EMAIL","value":"newcontact_x_1466963485@hsgem.com","timestamp":1466963483646},{"type":"LEAD_GUID","value":"696627d6-ba4b-4469-8205-16d4b7040d45","timestamp":1466963483650}]}],"merge-audits":[]}'
     http_version: 
   recorded_at: Sun, 26 Jun 2016 17:51:25 GMT
+- request:
+    method: post
+    uri: https://api.hubapi.com/contacts/v1/contact/createOrUpdate/email/newcontact_x_1467152215@hsgem.com?hapikey=demo
+    body:
+      encoding: UTF-8
+      string: '{"properties":[{"property":"firstname","value":"Hugh"},{"property":"lastname","value":"Jackman"}]}'
+    headers:
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      Content-Length:
+      - '28'
+      Date:
+      - Tue, 28 Jun 2016 22:16:56 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"vid":1953925,"isNew":true}'
+    http_version: 
+  recorded_at: Tue, 28 Jun 2016 22:16:56 GMT
+- request:
+    method: get
+    uri: https://api.hubapi.com/contacts/v1/contact/vid/1953925/profile?hapikey=demo
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers: {}
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      Content-Length:
+      - '2479'
+      Date:
+      - Tue, 28 Jun 2016 22:16:56 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"vid":1953925,"canonical-vid":1953925,"merged-vids":[],"portal-id":62515,"is-contact":true,"profile-token":"AO_T-mMWpk42HSVu9BMrvMns4K4rzQ46b4-DqsHMGv31j1_SuFWYDcrxuP3Bwe22KrZtTEhxWF5ebhncaybBkOmRrwLWaoIYIpwFijz6J_z_rwhD2ip4qZEEmY0lNV4lSltqqDjwxrAP","profile-url":"https://app.hubspot.com/contacts/62515/lists/public/contact/_AO_T-mMWpk42HSVu9BMrvMns4K4rzQ46b4-DqsHMGv31j1_SuFWYDcrxuP3Bwe22KrZtTEhxWF5ebhncaybBkOmRrwLWaoIYIpwFijz6J_z_rwhD2ip4qZEEmY0lNV4lSltqqDjwxrAP/","properties":{"firstname":{"value":"Hugh","versions":[{"value":"Hugh","source-type":"API","source-id":null,"source-label":null,"timestamp":1467152216143,"selected":false}]},"lastmodifieddate":{"value":"1467152216247","versions":[{"value":"1467152216247","source-type":"CALCULATED","source-id":null,"source-label":null,"timestamp":1467152216247,"selected":false}]},"num_conversion_events":{"value":"0","versions":[{"value":"0","source-type":"CALCULATED","source-id":null,"source-label":null,"timestamp":0,"selected":false}]},"num_unique_conversion_events":{"value":"0","versions":[{"value":"0","source-type":"CALCULATED","source-id":null,"source-label":null,"timestamp":0,"selected":false}]},"createdate":{"value":"1467152216165","versions":[{"value":"1467152216165","source-type":"API","source-id":"contact-upsert","source-label":null,"timestamp":1467152216165,"selected":false}]},"hs_lifecyclestage_subscriber_date":{"value":"1467152216165","versions":[{"value":"1467152216165","source-type":"API","source-id":null,"source-label":null,"timestamp":1467152216165,"selected":false}]},"lifecyclestage":{"value":"subscriber","versions":[{"value":"subscriber","source-type":"API","source-id":null,"source-label":null,"timestamp":1467152216165,"selected":false}]},"email":{"value":"newcontact_x_1467152215@hsgem.com","versions":[{"value":"newcontact_x_1467152215@hsgem.com","source-type":"API","source-id":"contact-upsert","source-label":null,"timestamp":1467152216165,"selected":false}]},"lastname":{"value":"Jackman","versions":[{"value":"Jackman","source-type":"API","source-id":null,"source-label":null,"timestamp":1467152216143,"selected":false}]}},"form-submissions":[],"list-memberships":[],"identity-profiles":[{"vid":1953925,"saved-at-timestamp":1467152216167,"deleted-changed-timestamp":0,"identities":[{"type":"EMAIL","value":"newcontact_x_1467152215@hsgem.com","timestamp":1467152216165},{"type":"LEAD_GUID","value":"535c90d3-ba47-46ff-bce0-3e5604cca82b","timestamp":1467152216166}]}],"merge-audits":[]}'
+    http_version: 
+  recorded_at: Tue, 28 Jun 2016 22:16:56 GMT
+- request:
+    method: post
+    uri: https://api.hubapi.com/contacts/v1/contact/createOrUpdate/email/newcontact_x_1467152216@hsgem.com?hapikey=demo
+    body:
+      encoding: UTF-8
+      string: '{"properties":[{"property":"firstname","value":"Hugh"},{"property":"lastname","value":"Jackman"}]}'
+    headers:
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      Content-Length:
+      - '28'
+      Date:
+      - Tue, 28 Jun 2016 22:16:56 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"vid":1953875,"isNew":true}'
+    http_version: 
+  recorded_at: Tue, 28 Jun 2016 22:16:56 GMT
+- request:
+    method: get
+    uri: https://api.hubapi.com/contacts/v1/contact/vid/1953875/profile?hapikey=demo
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers: {}
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      Content-Length:
+      - '2479'
+      Date:
+      - Tue, 28 Jun 2016 22:16:56 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"vid":1953875,"canonical-vid":1953875,"merged-vids":[],"portal-id":62515,"is-contact":true,"profile-token":"AO_T-mP3NOtYah2BDUhmiBO38P1zHGB9tUzv9rNJnrwixe9bh2augFtlIQOt0HjB7HgJCLhMnuoN7ESecHmd0HsI5YPPwVO_uOGDH0CgwwEa5EwZfz72-TFEdMhrLpnUngKVeYTsuHGf","profile-url":"https://app.hubspot.com/contacts/62515/lists/public/contact/_AO_T-mP3NOtYah2BDUhmiBO38P1zHGB9tUzv9rNJnrwixe9bh2augFtlIQOt0HjB7HgJCLhMnuoN7ESecHmd0HsI5YPPwVO_uOGDH0CgwwEa5EwZfz72-TFEdMhrLpnUngKVeYTsuHGf/","properties":{"firstname":{"value":"Hugh","versions":[{"value":"Hugh","source-type":"API","source-id":null,"source-label":null,"timestamp":1467152216553,"selected":false}]},"lastmodifieddate":{"value":"1467152216653","versions":[{"value":"1467152216653","source-type":"CALCULATED","source-id":null,"source-label":null,"timestamp":1467152216653,"selected":false}]},"num_conversion_events":{"value":"0","versions":[{"value":"0","source-type":"CALCULATED","source-id":null,"source-label":null,"timestamp":0,"selected":false}]},"num_unique_conversion_events":{"value":"0","versions":[{"value":"0","source-type":"CALCULATED","source-id":null,"source-label":null,"timestamp":0,"selected":false}]},"createdate":{"value":"1467152216581","versions":[{"value":"1467152216581","source-type":"API","source-id":"contact-upsert","source-label":null,"timestamp":1467152216581,"selected":false}]},"hs_lifecyclestage_subscriber_date":{"value":"1467152216581","versions":[{"value":"1467152216581","source-type":"API","source-id":null,"source-label":null,"timestamp":1467152216581,"selected":false}]},"lifecyclestage":{"value":"subscriber","versions":[{"value":"subscriber","source-type":"API","source-id":null,"source-label":null,"timestamp":1467152216581,"selected":false}]},"email":{"value":"newcontact_x_1467152216@hsgem.com","versions":[{"value":"newcontact_x_1467152216@hsgem.com","source-type":"API","source-id":"contact-upsert","source-label":null,"timestamp":1467152216581,"selected":false}]},"lastname":{"value":"Jackman","versions":[{"value":"Jackman","source-type":"API","source-id":null,"source-label":null,"timestamp":1467152216553,"selected":false}]}},"form-submissions":[],"list-memberships":[],"identity-profiles":[{"vid":1953875,"saved-at-timestamp":1467152216588,"deleted-changed-timestamp":0,"identities":[{"type":"EMAIL","value":"newcontact_x_1467152216@hsgem.com","timestamp":1467152216581},{"type":"LEAD_GUID","value":"100d18e6-eb8b-45ad-9e85-548b8ce44b06","timestamp":1467152216588}]}],"merge-audits":[]}'
+    http_version: 
+  recorded_at: Tue, 28 Jun 2016 22:16:56 GMT
+- request:
+    method: post
+    uri: https://api.hubapi.com/contacts/v1/contact/createOrUpdate/email/newcontact_x_1467152874@hsgem.com?hapikey=demo
+    body:
+      encoding: UTF-8
+      string: '{"properties":[{"property":"firstname","value":"Hugh"},{"property":"lastname","value":"Jackman"}]}'
+    headers:
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      Content-Length:
+      - '28'
+      Date:
+      - Tue, 28 Jun 2016 22:27:54 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"vid":1954025,"isNew":true}'
+    http_version: 
+  recorded_at: Tue, 28 Jun 2016 22:27:54 GMT
+- request:
+    method: get
+    uri: https://api.hubapi.com/contacts/v1/contact/vid/1954025/profile?hapikey=demo
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers: {}
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      Content-Length:
+      - '2479'
+      Date:
+      - Tue, 28 Jun 2016 22:27:55 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"vid":1954025,"canonical-vid":1954025,"merged-vids":[],"portal-id":62515,"is-contact":true,"profile-token":"AO_T-mN4xW3wMGT8_BlVQBiu77PwPx2f2lntrnoIm0jUy-YhraKVFtTu2PkUkc3Rxc9fVwUI5Sf6eiRK9uzI_xbQW4DTmMT2rvXGnaE36rU0lMREFYSbLAFNofkdPEoS552DSLaPO1gp","profile-url":"https://app.hubspot.com/contacts/62515/lists/public/contact/_AO_T-mN4xW3wMGT8_BlVQBiu77PwPx2f2lntrnoIm0jUy-YhraKVFtTu2PkUkc3Rxc9fVwUI5Sf6eiRK9uzI_xbQW4DTmMT2rvXGnaE36rU0lMREFYSbLAFNofkdPEoS552DSLaPO1gp/","properties":{"firstname":{"value":"Hugh","versions":[{"value":"Hugh","source-type":"API","source-id":null,"source-label":null,"timestamp":1467152874673,"selected":false}]},"lastmodifieddate":{"value":"1467152874768","versions":[{"value":"1467152874768","source-type":"CALCULATED","source-id":null,"source-label":null,"timestamp":1467152874768,"selected":false}]},"num_conversion_events":{"value":"0","versions":[{"value":"0","source-type":"CALCULATED","source-id":null,"source-label":null,"timestamp":0,"selected":false}]},"num_unique_conversion_events":{"value":"0","versions":[{"value":"0","source-type":"CALCULATED","source-id":null,"source-label":null,"timestamp":0,"selected":false}]},"createdate":{"value":"1467152874699","versions":[{"value":"1467152874699","source-type":"API","source-id":"contact-upsert","source-label":null,"timestamp":1467152874699,"selected":false}]},"hs_lifecyclestage_subscriber_date":{"value":"1467152874699","versions":[{"value":"1467152874699","source-type":"API","source-id":null,"source-label":null,"timestamp":1467152874699,"selected":false}]},"lifecyclestage":{"value":"subscriber","versions":[{"value":"subscriber","source-type":"API","source-id":null,"source-label":null,"timestamp":1467152874699,"selected":false}]},"email":{"value":"newcontact_x_1467152874@hsgem.com","versions":[{"value":"newcontact_x_1467152874@hsgem.com","source-type":"API","source-id":"contact-upsert","source-label":null,"timestamp":1467152874699,"selected":false}]},"lastname":{"value":"Jackman","versions":[{"value":"Jackman","source-type":"API","source-id":null,"source-label":null,"timestamp":1467152874673,"selected":false}]}},"form-submissions":[],"list-memberships":[],"identity-profiles":[{"vid":1954025,"saved-at-timestamp":1467152874705,"deleted-changed-timestamp":0,"identities":[{"type":"EMAIL","value":"newcontact_x_1467152874@hsgem.com","timestamp":1467152874699},{"type":"LEAD_GUID","value":"a37f91ff-900b-449e-8b9d-153672452fa6","timestamp":1467152874704}]}],"merge-audits":[]}'
+    http_version: 
+  recorded_at: Tue, 28 Jun 2016 22:27:55 GMT
+- request:
+    method: post
+    uri: https://api.hubapi.com/contacts/v1/contact/createOrUpdate/email/newcontact_x_1467152875@hsgem.com?hapikey=demo
+    body:
+      encoding: UTF-8
+      string: '{"properties":[{"property":"firstname","value":"Hugh"},{"property":"lastname","value":"Jackman"}]}'
+    headers:
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      Content-Length:
+      - '28'
+      Date:
+      - Tue, 28 Jun 2016 22:27:55 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"vid":1954124,"isNew":true}'
+    http_version: 
+  recorded_at: Tue, 28 Jun 2016 22:27:55 GMT
+- request:
+    method: get
+    uri: https://api.hubapi.com/contacts/v1/contact/vid/1954124/profile?hapikey=demo
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers: {}
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      Content-Length:
+      - '2479'
+      Date:
+      - Tue, 28 Jun 2016 22:27:55 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"vid":1954124,"canonical-vid":1954124,"merged-vids":[],"portal-id":62515,"is-contact":true,"profile-token":"AO_T-mOpX_XUwa7XllAhIRTtbpO2QVTIXx3LVj9C5uW4fM7YTpaRvmp58Gzvj3d_Bzjc-XBhMl9mpmLldj2uKIMsklj-YlMG7s_f3sp_ISOojPf468GhrRfI8j3v1f5qQyhw72vezvk8","profile-url":"https://app.hubspot.com/contacts/62515/lists/public/contact/_AO_T-mOpX_XUwa7XllAhIRTtbpO2QVTIXx3LVj9C5uW4fM7YTpaRvmp58Gzvj3d_Bzjc-XBhMl9mpmLldj2uKIMsklj-YlMG7s_f3sp_ISOojPf468GhrRfI8j3v1f5qQyhw72vezvk8/","properties":{"firstname":{"value":"Hugh","versions":[{"value":"Hugh","source-type":"API","source-id":null,"source-label":null,"timestamp":1467152875483,"selected":false}]},"lastmodifieddate":{"value":"1467152875571","versions":[{"value":"1467152875571","source-type":"CALCULATED","source-id":null,"source-label":null,"timestamp":1467152875571,"selected":false}]},"num_conversion_events":{"value":"0","versions":[{"value":"0","source-type":"CALCULATED","source-id":null,"source-label":null,"timestamp":0,"selected":false}]},"num_unique_conversion_events":{"value":"0","versions":[{"value":"0","source-type":"CALCULATED","source-id":null,"source-label":null,"timestamp":0,"selected":false}]},"createdate":{"value":"1467152875500","versions":[{"value":"1467152875500","source-type":"API","source-id":"contact-upsert","source-label":null,"timestamp":1467152875500,"selected":false}]},"hs_lifecyclestage_subscriber_date":{"value":"1467152875500","versions":[{"value":"1467152875500","source-type":"API","source-id":null,"source-label":null,"timestamp":1467152875500,"selected":false}]},"lifecyclestage":{"value":"subscriber","versions":[{"value":"subscriber","source-type":"API","source-id":null,"source-label":null,"timestamp":1467152875500,"selected":false}]},"email":{"value":"newcontact_x_1467152875@hsgem.com","versions":[{"value":"newcontact_x_1467152875@hsgem.com","source-type":"API","source-id":"contact-upsert","source-label":null,"timestamp":1467152875500,"selected":false}]},"lastname":{"value":"Jackman","versions":[{"value":"Jackman","source-type":"API","source-id":null,"source-label":null,"timestamp":1467152875483,"selected":false}]}},"form-submissions":[],"list-memberships":[],"identity-profiles":[{"vid":1954124,"saved-at-timestamp":1467152875509,"deleted-changed-timestamp":0,"identities":[{"type":"EMAIL","value":"newcontact_x_1467152875@hsgem.com","timestamp":1467152875500},{"type":"LEAD_GUID","value":"4510ceb1-83c8-4e7f-a24d-4dbe3d7b5d0e","timestamp":1467152875505}]}],"merge-audits":[]}'
+    http_version: 
+  recorded_at: Tue, 28 Jun 2016 22:27:55 GMT
 recorded_with: VCR 2.4.0

--- a/spec/fixtures/vcr_cassettes/engagement_create.yml
+++ b/spec/fixtures/vcr_cassettes/engagement_create.yml
@@ -1,0 +1,42 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.hubapi.com/engagements/v1/engagements?hapikey=demo
+    body:
+      encoding: UTF-8
+      string: '{"engagement":{"type":"NOTE"},"associations":{"contactIds":[null]},"metadata":{"body":"Test
+        note"}}'
+    headers:
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Access-Control-Allow-Headers:
+      - Origin, X-Requested-With, Content-Type, Accept, Accept-Charset, Accept-Encoding,
+        X-Override-Internal-Permissions, X-Properties-Source, X-Properties-SourceId,
+        X-Properties-Flag, X-Hubspot-User-Id, X-Hubspot-Trace, X-Hubspot-Callee, X-Hubspot-Offset,
+        X-Hubspot-No-Trace, X-HubSpot-Request-Source, X-HubSpot-Request-Reason, Subscription-Billing-Auth-Token,
+        X-App-CSRF, X-Tools-CSRF, Online-Payment-Signing-UUID, X-Source, X-SourceId
+      Access-Control-Allow-Methods:
+      - GET, OPTIONS, PUT, POST, DELETE, PATCH, HEAD
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '280'
+      Date:
+      - Wed, 29 Jun 2016 20:10:19 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"engagement":{"id":74241847,"portalId":62515,"active":true,"createdAt":1467231019741,"lastUpdated":1467231019741,"type":"NOTE","timestamp":1467231019741},"associations":{"contactIds":[],"companyIds":[],"dealIds":[],"ownerIds":[],"workflowIds":[]},"metadata":{"body":"Test
+        note"}}'
+    http_version: 
+  recorded_at: Wed, 29 Jun 2016 20:10:19 GMT
+recorded_with: VCR 2.4.0

--- a/spec/fixtures/vcr_cassettes/engagement_destroy.yml
+++ b/spec/fixtures/vcr_cassettes/engagement_destroy.yml
@@ -1,0 +1,146 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.hubapi.com/engagements/v1/engagements?hapikey=demo
+    body:
+      encoding: UTF-8
+      string: '{"engagement":{"type":"NOTE"},"associations":{"contactIds":[null]},"metadata":{"body":"test
+        note"}}'
+    headers:
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Access-Control-Allow-Headers:
+      - Origin, X-Requested-With, Content-Type, Accept, Accept-Charset, Accept-Encoding,
+        X-Override-Internal-Permissions, X-Properties-Source, X-Properties-SourceId,
+        X-Properties-Flag, X-Hubspot-User-Id, X-Hubspot-Trace, X-Hubspot-Callee, X-Hubspot-Offset,
+        X-Hubspot-No-Trace, X-HubSpot-Request-Source, X-HubSpot-Request-Reason, Subscription-Billing-Auth-Token,
+        X-App-CSRF, X-Tools-CSRF, Online-Payment-Signing-UUID, X-Source, X-SourceId
+      Access-Control-Allow-Methods:
+      - GET, OPTIONS, PUT, POST, DELETE, PATCH, HEAD
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '280'
+      Date:
+      - Wed, 29 Jun 2016 20:26:45 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"engagement":{"id":92819546,"portalId":62515,"active":true,"createdAt":1467232005455,"lastUpdated":1467232005455,"type":"NOTE","timestamp":1467232005455},"associations":{"contactIds":[],"companyIds":[],"dealIds":[],"ownerIds":[],"workflowIds":[]},"metadata":{"body":"test
+        note"}}'
+    http_version: 
+  recorded_at: Wed, 29 Jun 2016 20:26:45 GMT
+- request:
+    method: get
+    uri: https://api.hubapi.com/engagements/v1/engagements/92819546?hapikey=demo
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers: {}
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Access-Control-Allow-Headers:
+      - Origin, X-Requested-With, Content-Type, Accept, Accept-Charset, Accept-Encoding,
+        X-Override-Internal-Permissions, X-Properties-Source, X-Properties-SourceId,
+        X-Properties-Flag, X-Hubspot-User-Id, X-Hubspot-Trace, X-Hubspot-Callee, X-Hubspot-Offset,
+        X-Hubspot-No-Trace, X-HubSpot-Request-Source, X-HubSpot-Request-Reason, Subscription-Billing-Auth-Token,
+        X-App-CSRF, X-Tools-CSRF, Online-Payment-Signing-UUID, X-Source, X-SourceId
+      Access-Control-Allow-Methods:
+      - GET, OPTIONS, PUT, POST, DELETE, PATCH, HEAD
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '280'
+      Date:
+      - Wed, 29 Jun 2016 20:26:45 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"engagement":{"id":92819546,"portalId":62515,"active":true,"createdAt":1467232005455,"lastUpdated":1467232005455,"type":"NOTE","timestamp":1467232005455},"associations":{"contactIds":[],"companyIds":[],"dealIds":[],"ownerIds":[],"workflowIds":[]},"metadata":{"body":"test
+        note"}}'
+    http_version: 
+  recorded_at: Wed, 29 Jun 2016 20:26:45 GMT
+- request:
+    method: delete
+    uri: https://api.hubapi.com/engagements/v1/engagements/92819546?hapikey=demo
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers: {}
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Access-Control-Allow-Headers:
+      - Origin, X-Requested-With, Content-Type, Accept, Accept-Charset, Accept-Encoding,
+        X-Override-Internal-Permissions, X-Properties-Source, X-Properties-SourceId,
+        X-Properties-Flag, X-Hubspot-User-Id, X-Hubspot-Trace, X-Hubspot-Callee, X-Hubspot-Offset,
+        X-Hubspot-No-Trace, X-HubSpot-Request-Source, X-HubSpot-Request-Reason, Subscription-Billing-Auth-Token,
+        X-App-CSRF, X-Tools-CSRF, Online-Payment-Signing-UUID, X-Source, X-SourceId
+      Access-Control-Allow-Methods:
+      - GET, OPTIONS, PUT, POST, DELETE, PATCH, HEAD
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Wed, 29 Jun 2016 20:26:53 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 29 Jun 2016 20:26:53 GMT
+- request:
+    method: get
+    uri: https://api.hubapi.com/engagements/v1/engagements/92819546?hapikey=demo
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers: {}
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Access-Control-Allow-Headers:
+      - Origin, X-Requested-With, Content-Type, Accept, Accept-Charset, Accept-Encoding,
+        X-Override-Internal-Permissions, X-Properties-Source, X-Properties-SourceId,
+        X-Properties-Flag, X-Hubspot-User-Id, X-Hubspot-Trace, X-Hubspot-Callee, X-Hubspot-Offset,
+        X-Hubspot-No-Trace, X-HubSpot-Request-Source, X-HubSpot-Request-Reason, Subscription-Billing-Auth-Token,
+        X-App-CSRF, X-Tools-CSRF, Online-Payment-Signing-UUID, X-Source, X-SourceId
+      Access-Control-Allow-Methods:
+      - GET, OPTIONS, PUT, POST, DELETE, PATCH, HEAD
+      X-Hubspot-Notfound:
+      - 'true'
+      Content-Length:
+      - '0'
+      Date:
+      - Wed, 29 Jun 2016 20:27:11 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Wed, 29 Jun 2016 20:27:11 GMT
+recorded_with: VCR 2.4.0

--- a/spec/fixtures/vcr_cassettes/engagement_example.yml
+++ b/spec/fixtures/vcr_cassettes/engagement_example.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubapi.com/engagements/v1/engagements/51484873?hapikey=demo
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers: {}
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Access-Control-Allow-Headers:
+      - Origin, X-Requested-With, Content-Type, Accept, Accept-Charset, Accept-Encoding,
+        X-Override-Internal-Permissions, X-Properties-Source, X-Properties-SourceId,
+        X-Properties-Flag, X-Hubspot-User-Id, X-Hubspot-Trace, X-Hubspot-Callee, X-Hubspot-Offset,
+        X-Hubspot-No-Trace, X-HubSpot-Request-Source, X-HubSpot-Request-Reason, Subscription-Billing-Auth-Token,
+        X-App-CSRF, X-Tools-CSRF, Online-Payment-Signing-UUID, X-Source, X-SourceId
+      Access-Control-Allow-Methods:
+      - GET, OPTIONS, PUT, POST, DELETE, PATCH, HEAD
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '292'
+      Date:
+      - Wed, 29 Jun 2016 20:04:30 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"engagement":{"id":51484873,"portalId":62515,"active":true,"createdAt":1450278022053,"lastUpdated":1450278022053,"ownerId":1,"type":"NOTE","timestamp":1409172644778},"associations":{"contactIds":[],"companyIds":[],"dealIds":[],"ownerIds":[],"workflowIds":[]},"metadata":{"body":"note
+        body"}}'
+    http_version: 
+  recorded_at: Wed, 29 Jun 2016 20:04:30 GMT
+recorded_with: VCR 2.4.0

--- a/spec/fixtures/vcr_cassettes/engagement_find.yml
+++ b/spec/fixtures/vcr_cassettes/engagement_find.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubapi.com/engagements/v1/engagements/51484873?hapikey=demo
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers: {}
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Access-Control-Allow-Headers:
+      - Origin, X-Requested-With, Content-Type, Accept, Accept-Charset, Accept-Encoding,
+        X-Override-Internal-Permissions, X-Properties-Source, X-Properties-SourceId,
+        X-Properties-Flag, X-Hubspot-User-Id, X-Hubspot-Trace, X-Hubspot-Callee, X-Hubspot-Offset,
+        X-Hubspot-No-Trace, X-HubSpot-Request-Source, X-HubSpot-Request-Reason, Subscription-Billing-Auth-Token,
+        X-App-CSRF, X-Tools-CSRF, Online-Payment-Signing-UUID, X-Source, X-SourceId
+      Access-Control-Allow-Methods:
+      - GET, OPTIONS, PUT, POST, DELETE, PATCH, HEAD
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '292'
+      Date:
+      - Wed, 29 Jun 2016 20:24:10 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"engagement":{"id":51484873,"portalId":62515,"active":true,"createdAt":1450278022053,"lastUpdated":1450278022053,"ownerId":1,"type":"NOTE","timestamp":1409172644778},"associations":{"contactIds":[],"companyIds":[],"dealIds":[],"ownerIds":[],"workflowIds":[]},"metadata":{"body":"note
+        body"}}'
+    http_version: 
+  recorded_at: Wed, 29 Jun 2016 20:24:10 GMT
+recorded_with: VCR 2.4.0

--- a/spec/lib/hubspot/engagement_spec.rb
+++ b/spec/lib/hubspot/engagement_spec.rb
@@ -26,7 +26,7 @@ describe Hubspot::Engagement do
     cassette "engagement_find"
     let(:engagement) {Hubspot::EngagementNote.new(example_engagement_hash)}
 
-    it 'must find by the deal id' do
+    it 'must find by the engagement id' do
       find_engagement = Hubspot::EngagementNote.find(engagement.id)
       find_engagement.id.should eql engagement.id
       find_engagement.body.should eql engagement.body

--- a/spec/lib/hubspot/engagement_spec.rb
+++ b/spec/lib/hubspot/engagement_spec.rb
@@ -1,0 +1,50 @@
+describe Hubspot::Engagement do
+  let(:example_engagement_hash) do
+    VCR.use_cassette("engagement_example") do
+      HTTParty.get("https://api.hubapi.com/engagements/v1/engagements/51484873?hapikey=demo").parsed_response
+    end
+  end
+
+  # http://developers.hubspot.com/docs/methods/contacts/get_contact
+  before{ Hubspot.configure(hapikey: "demo") }
+
+  describe "#initialize" do
+    subject{ Hubspot::Engagement.new(example_engagement_hash) }
+    it  { should be_an_instance_of Hubspot::Engagement }
+    its (:id) { should == 51484873 }
+  end
+
+  describe ".create!" do
+    cassette "engagement_create"
+    body = "Test note"
+    subject { Hubspot::EngagementNote.create!(nil, body) }
+    its(:id) { should_not be_nil }
+    its(:body) { should eql body }
+  end
+
+  describe ".find" do
+    cassette "engagement_find"
+    let(:engagement) {Hubspot::EngagementNote.new(example_engagement_hash)}
+
+    it 'must find by the deal id' do
+      find_engagement = Hubspot::EngagementNote.find(engagement.id)
+      find_engagement.id.should eql engagement.id
+      find_engagement.body.should eql engagement.body
+    end
+  end
+
+  describe '#destroy!' do
+    cassette 'engagement_destroy'
+
+    let(:engagement) {Hubspot::EngagementNote.create!(nil, 'test note') }
+
+    it 'should remove from hubspot' do
+      expect(Hubspot::Engagement.find(engagement.id)).to_not be_nil
+
+      expect(engagement.destroy!).to be_true
+      expect(engagement.destroyed?).to be_true
+
+      expect(Hubspot::Engagement.find(engagement.id)).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Added support for [engagements](http://developers.hubspot.com/docs/methods/engagements/create_engagement) and tried to match style/coverage standards. Currently only particularly useful with the `Hubspot:EngagementNote` subclass, but built in such a way to allow for future expansion.