### PR TITLE
Feature/call engagement

### DIFF
--- a/lib/hubspot/engagement.rb
+++ b/lib/hubspot/engagement.rb
@@ -149,7 +149,7 @@ module Hubspot
     end
 
     class << self
-      def create!(contact_vid, body, duration, owner_id = nil, deal_id = nil, status = 'COMPLETED')
+      def create!(contact_vid, body, duration, owner_id = nil, deal_id = nil, status = 'COMPLETED', time = nil)
         data = {
           engagement: {
             type: 'CALL'
@@ -166,6 +166,7 @@ module Hubspot
           }
         }
 
+        data[:engagement][:timestamp] = (time.to_i) * 1000 if time
         # copypasta from NoteEngagement, seems wrong
         data[:engagement][:owner_id] = owner_id if owner_id
 

--- a/lib/hubspot/engagement.rb
+++ b/lib/hubspot/engagement.rb
@@ -130,4 +130,45 @@ module Hubspot
       end
     end
   end
+
+  class EngagementCall < Engagement
+    def body
+      metadata['body']
+    end
+
+    def contact_ids
+      associations['contactIds']
+    end
+
+    def company_ids
+      associations['companyIds']
+    end
+
+    def deal_ids
+      associations['dealIds']
+    end
+
+    class << self
+      def create!(contact_vid, body, duration, owner_id = nil, deal_id = nil, status = 'COMPLETED')
+        data = {
+          engagement: {
+            type: 'CALL'
+          },
+          associations: {
+            contactIds: [contact_vid],
+            dealIds: [deal_id]
+          },
+          metadata: {
+            body: body,
+            status: status
+          }
+        }
+
+        # if the owner id has been provided, append it to the engagement
+        data[:engagement][:owner_id] = owner_id if owner_id
+
+        super(data)
+      end
+    end
+  end
 end

--- a/lib/hubspot/engagement.rb
+++ b/lib/hubspot/engagement.rb
@@ -33,7 +33,7 @@ module Hubspot
       def find(engagement_id)
         begin
           response = Hubspot::Connection.get_json(ENGAGEMENT_PATH, { engagement_id: engagement_id })
-          new(HashWithIndifferentAccess.new(response))
+          response ? new(HashWithIndifferentAccess.new(response)) : nil
         rescue Hubspot::RequestError => ex
           if ex.response.code == 404
             return nil
@@ -167,7 +167,6 @@ module Hubspot
         }
 
         data[:engagement][:timestamp] = (time.to_i) * 1000 if time
-        # copypasta from NoteEngagement, seems wrong
         data[:engagement][:owner_id] = owner_id if owner_id
 
         super(data)

--- a/lib/hubspot/engagement.rb
+++ b/lib/hubspot/engagement.rb
@@ -156,15 +156,17 @@ module Hubspot
           },
           associations: {
             contactIds: [contact_vid],
-            dealIds: [deal_id]
+            dealIds: [deal_id],
+            ownerIds: [owner_id]
           },
           metadata: {
             body: body,
-            status: status
+            status: status,
+            durationMilliseconds: duration
           }
         }
 
-        # if the owner id has been provided, append it to the engagement
+        # copypasta from NoteEngagement, seems wrong
         data[:engagement][:owner_id] = owner_id if owner_id
 
         super(data)

--- a/spec/fixtures/vcr_cassettes/engagement_call_create.yml
+++ b/spec/fixtures/vcr_cassettes/engagement_call_create.yml
@@ -1,0 +1,42 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.hubapi.com/engagements/v1/engagements?hapikey=demo
+    body:
+      encoding: UTF-8
+      string: '{"engagement":{"type":"CALL"},"associations":{"contactIds":[null],"dealIds":[null],"ownerIds":[null]},"metadata":{"body":"Test
+        call","status":"COMPLETED","durationMilliseconds":0}}'
+    headers:
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Access-Control-Allow-Headers:
+      - Origin, X-Requested-With, Content-Type, Accept, Accept-Charset, Accept-Encoding,
+        X-Override-Internal-Permissions, X-Properties-Source, X-Properties-SourceId,
+        X-Properties-Flag, X-Hubspot-User-Id, X-Hubspot-Trace, X-Hubspot-Callee, X-Hubspot-Offset,
+        X-Hubspot-No-Trace, X-HubSpot-Request-Source, X-HubSpot-Request-Reason, Subscription-Billing-Auth-Token,
+        X-App-CSRF, X-Tools-CSRF, Online-Payment-Signing-UUID, X-Source, X-SourceId
+      Access-Control-Allow-Methods:
+      - GET, OPTIONS, PUT, POST, DELETE, PATCH, HEAD
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '327'
+      Date:
+      - Thu, 15 Dec 2016 14:25:08 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"engagement":{"id":185916081,"portalId":62515,"active":true,"createdAt":1481811908160,"lastUpdated":1481811908160,"type":"CALL","timestamp":1481811908160},"associations":{"contactIds":[],"companyIds":[],"dealIds":[],"ownerIds":[],"workflowIds":[]},"metadata":{"status":"COMPLETED","durationMilliseconds":0,"body":"Test
+        call"}}'
+    http_version: 
+  recorded_at: Thu, 15 Dec 2016 14:25:08 GMT
+recorded_with: VCR 2.4.0

--- a/spec/fixtures/vcr_cassettes/engagement_call_destroy.yml
+++ b/spec/fixtures/vcr_cassettes/engagement_call_destroy.yml
@@ -5,8 +5,8 @@ http_interactions:
     uri: https://api.hubapi.com/engagements/v1/engagements?hapikey=demo
     body:
       encoding: UTF-8
-      string: '{"engagement":{"type":"NOTE"},"associations":{"contactIds":[null]},"metadata":{"body":"test
-        note"}}'
+      string: '{"engagement":{"type":"CALL"},"associations":{"contactIds":[null],"dealIds":[null],"ownerIds":[null]},"metadata":{"body":"test
+        call","status":"COMPLETED","durationMilliseconds":0}}'
     headers:
       Content-Type:
       - application/json
@@ -28,20 +28,20 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Content-Length:
-      - '281'
+      - '327'
       Date:
-      - Thu, 15 Dec 2016 14:38:32 GMT
+      - Thu, 15 Dec 2016 14:38:33 GMT
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"engagement":{"id":185949811,"portalId":62515,"active":true,"createdAt":1481812712677,"lastUpdated":1481812712677,"type":"NOTE","timestamp":1481812712677},"associations":{"contactIds":[],"companyIds":[],"dealIds":[],"ownerIds":[],"workflowIds":[]},"metadata":{"body":"test
-        note"}}'
+      string: '{"engagement":{"id":185949816,"portalId":62515,"active":true,"createdAt":1481812713434,"lastUpdated":1481812713434,"type":"CALL","timestamp":1481812713434},"associations":{"contactIds":[],"companyIds":[],"dealIds":[],"ownerIds":[],"workflowIds":[]},"metadata":{"status":"COMPLETED","durationMilliseconds":0,"body":"test
+        call"}}'
     http_version: 
-  recorded_at: Thu, 15 Dec 2016 14:38:32 GMT
+  recorded_at: Thu, 15 Dec 2016 14:38:33 GMT
 - request:
     method: get
-    uri: https://api.hubapi.com/engagements/v1/engagements/185949811?hapikey=demo
+    uri: https://api.hubapi.com/engagements/v1/engagements/185949816?hapikey=demo
     body:
       encoding: US-ASCII
       string: ''
@@ -64,20 +64,20 @@ http_interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Content-Length:
-      - '281'
+      - '327'
       Date:
-      - Thu, 15 Dec 2016 14:38:32 GMT
+      - Thu, 15 Dec 2016 14:38:33 GMT
       Connection:
       - keep-alive
     body:
       encoding: UTF-8
-      string: '{"engagement":{"id":185949811,"portalId":62515,"active":true,"createdAt":1481812712677,"lastUpdated":1481812712677,"type":"NOTE","timestamp":1481812712677},"associations":{"contactIds":[],"companyIds":[],"dealIds":[],"ownerIds":[],"workflowIds":[]},"metadata":{"body":"test
-        note"}}'
+      string: '{"engagement":{"id":185949816,"portalId":62515,"active":true,"createdAt":1481812713434,"lastUpdated":1481812713434,"type":"CALL","timestamp":1481812713434},"associations":{"contactIds":[],"companyIds":[],"dealIds":[],"ownerIds":[],"workflowIds":[]},"metadata":{"status":"COMPLETED","durationMilliseconds":0,"body":"test
+        call"}}'
     http_version: 
-  recorded_at: Thu, 15 Dec 2016 14:38:32 GMT
+  recorded_at: Thu, 15 Dec 2016 14:38:33 GMT
 - request:
     method: delete
-    uri: https://api.hubapi.com/engagements/v1/engagements/185949811?hapikey=demo
+    uri: https://api.hubapi.com/engagements/v1/engagements/185949816?hapikey=demo
     body:
       encoding: US-ASCII
       string: ''
@@ -110,7 +110,7 @@ http_interactions:
   recorded_at: Thu, 15 Dec 2016 14:38:33 GMT
 - request:
     method: get
-    uri: https://api.hubapi.com/engagements/v1/engagements/185949811?hapikey=demo
+    uri: https://api.hubapi.com/engagements/v1/engagements/185949816?hapikey=demo
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/engagement_call_example.yml
+++ b/spec/fixtures/vcr_cassettes/engagement_call_example.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubapi.com/engagements/v1/engagements/4709059?hapikey=demo
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers: {}
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Access-Control-Allow-Headers:
+      - Origin, X-Requested-With, Content-Type, Accept, Accept-Charset, Accept-Encoding,
+        X-Override-Internal-Permissions, X-Properties-Source, X-Properties-SourceId,
+        X-Properties-Flag, X-Hubspot-User-Id, X-Hubspot-Trace, X-Hubspot-Callee, X-Hubspot-Offset,
+        X-Hubspot-No-Trace, X-HubSpot-Request-Source, X-HubSpot-Request-Reason, Subscription-Billing-Auth-Token,
+        X-App-CSRF, X-Tools-CSRF, Online-Payment-Signing-UUID, X-Source, X-SourceId
+      Access-Control-Allow-Methods:
+      - GET, OPTIONS, PUT, POST, DELETE, PATCH, HEAD
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '373'
+      Date:
+      - Thu, 15 Dec 2016 14:25:36 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"engagement":{"id":4709059,"portalId":62515,"active":true,"createdAt":1428586724779,"lastUpdated":1479827851650,"createdBy":215482,"modifiedBy":215482,"ownerId":70,"type":"CALL","timestamp":1428565020000},"associations":{"contactIds":[],"companyIds":[],"dealIds":[],"ownerIds":[],"workflowIds":[]},"attachments":[],"metadata":{"durationMilliseconds":0,"body":"test
+        call"}}'
+    http_version: 
+  recorded_at: Thu, 15 Dec 2016 14:25:36 GMT
+recorded_with: VCR 2.4.0

--- a/spec/fixtures/vcr_cassettes/engagement_call_find.yml
+++ b/spec/fixtures/vcr_cassettes/engagement_call_find.yml
@@ -1,0 +1,39 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.hubapi.com/engagements/v1/engagements/4709059?hapikey=demo
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers: {}
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Access-Control-Allow-Headers:
+      - Origin, X-Requested-With, Content-Type, Accept, Accept-Charset, Accept-Encoding,
+        X-Override-Internal-Permissions, X-Properties-Source, X-Properties-SourceId,
+        X-Properties-Flag, X-Hubspot-User-Id, X-Hubspot-Trace, X-Hubspot-Callee, X-Hubspot-Offset,
+        X-Hubspot-No-Trace, X-HubSpot-Request-Source, X-HubSpot-Request-Reason, Subscription-Billing-Auth-Token,
+        X-App-CSRF, X-Tools-CSRF, Online-Payment-Signing-UUID, X-Source, X-SourceId
+      Access-Control-Allow-Methods:
+      - GET, OPTIONS, PUT, POST, DELETE, PATCH, HEAD
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '373'
+      Date:
+      - Thu, 15 Dec 2016 14:25:36 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"engagement":{"id":4709059,"portalId":62515,"active":true,"createdAt":1428586724779,"lastUpdated":1479827851650,"createdBy":215482,"modifiedBy":215482,"ownerId":70,"type":"CALL","timestamp":1428565020000},"associations":{"contactIds":[],"companyIds":[],"dealIds":[],"ownerIds":[],"workflowIds":[]},"attachments":[],"metadata":{"durationMilliseconds":0,"body":"test
+        call"}}'
+    http_version: 
+  recorded_at: Thu, 15 Dec 2016 14:25:36 GMT
+recorded_with: VCR 2.4.0

--- a/spec/lib/hubspot/engagement_spec.rb
+++ b/spec/lib/hubspot/engagement_spec.rb
@@ -19,69 +19,113 @@ describe Hubspot::Engagement do
     its (:id) { should == 51484873 }
   end
 
-  describe ".create!" do
-    cassette "engagement_create"
-    body = "Test note"
-    subject { Hubspot::EngagementNote.create!(nil, body) }
-    its(:id) { should_not be_nil }
-    its(:body) { should eql body }
-  end
+  describe 'EngagementNote' do
+    describe ".create!" do
+      cassette "engagement_create"
+      body = "Test note"
+      subject { Hubspot::EngagementNote.create!(nil, body) }
+      its(:id) { should_not be_nil }
+      its(:body) { should eql body }
+    end
 
-  describe ".find" do
-    cassette "engagement_find"
-    let(:engagement) {Hubspot::EngagementNote.new(example_engagement_hash)}
+    describe ".find" do
+      cassette "engagement_find"
+      let(:engagement) {Hubspot::EngagementNote.new(example_engagement_hash)}
 
-    it 'must find by the engagement id' do
-      find_engagement = Hubspot::EngagementNote.find(engagement.id)
-      find_engagement.id.should eql engagement.id
-      find_engagement.body.should eql engagement.body
+      it 'must find by the engagement id' do
+        find_engagement = Hubspot::EngagementNote.find(engagement.id)
+        find_engagement.id.should eql engagement.id
+        find_engagement.body.should eql engagement.body
+      end
+    end
+
+    describe ".find_by_company" do
+      cassette "engagement_find_by_country"
+      let(:engagement) {Hubspot::EngagementNote.new(example_associated_engagement_hash)}
+
+      it 'must find by company id' do
+        find_engagements = Hubspot::EngagementNote.find_by_company(engagement.associations["companyIds"].first)
+        find_engagements.should_not be_nil
+        find_engagements.any?{|engagement| engagement.id == engagement.id and engagement.body == engagement.body}.should be_true
+      end
+    end
+
+    describe ".find_by_contact" do
+      cassette "engagement_find_by_contact"
+      let(:engagement) {Hubspot::EngagementNote.new(example_associated_engagement_hash)}
+
+      it 'must find by contact id' do
+        find_engagements = Hubspot::EngagementNote.find_by_contact(engagement.associations["contactIds"].first)
+        find_engagements.should_not be_nil
+        find_engagements.any?{|engagement| engagement.id == engagement.id and engagement.body == engagement.body}.should be_true
+      end
+    end
+
+    describe ".find_by_association" do
+      cassette "engagement_find_by_association"
+
+      it 'must raise for fake association type' do
+        expect {
+          Hubspot::EngagementNote.find_by_association(1, 'FAKE_TYPE')
+        }.to raise_error
+      end
+    end
+
+    describe '#destroy!' do
+      cassette 'engagement_destroy'
+
+      let(:engagement) {Hubspot::EngagementNote.create!(nil, 'test note') }
+
+      it 'should remove from hubspot' do
+        expect(Hubspot::Engagement.find(engagement.id)).to_not be_nil
+
+        expect(engagement.destroy!).to be_true
+        expect(engagement.destroyed?).to be_true
+
+        expect(Hubspot::Engagement.find(engagement.id)).to be_nil
+      end
     end
   end
 
-  describe ".find_by_company" do
-    cassette "engagement_find_by_country"
-    let(:engagement) {Hubspot::EngagementNote.new(example_associated_engagement_hash)}
-
-    it 'must find by company id' do
-      find_engagements = Hubspot::EngagementNote.find_by_company(engagement.associations["companyIds"].first)
-      find_engagements.should_not be_nil
-      find_engagements.any?{|engagement| engagement.id == engagement.id and engagement.body == engagement.body}.should be_true
+  describe 'EngagementCall' do
+    let(:example_engagement_hash) do
+      VCR.use_cassette("engagement_call_example") do
+        HTTParty.get("https://api.hubapi.com/engagements/v1/engagements/4709059?hapikey=demo").parsed_response
+      end
     end
-  end
 
-  describe ".find_by_contact" do
-    cassette "engagement_find_by_contact"
-    let(:engagement) {Hubspot::EngagementNote.new(example_associated_engagement_hash)}
-
-    it 'must find by contact id' do
-      find_engagements = Hubspot::EngagementNote.find_by_contact(engagement.associations["contactIds"].first)
-      find_engagements.should_not be_nil
-      find_engagements.any?{|engagement| engagement.id == engagement.id and engagement.body == engagement.body}.should be_true
+    describe ".create!" do
+      cassette "engagement_call_create"
+      body = "Test call"
+      subject { Hubspot::EngagementCall.create!(nil, body, 0) }
+      its(:id) { should_not be_nil }
+      its(:body) { should eql body }
     end
-  end
 
-  describe ".find_by_association" do
-    cassette "engagement_find_by_association"
+    describe ".find" do
+      cassette "engagement_call_find"
+      let(:engagement) { Hubspot::EngagementNote.new(example_engagement_hash) }
 
-    it 'must raise for fake association type' do
-      expect {
-        Hubspot::EngagementNote.find_by_association(1, 'FAKE_TYPE')
-      }.to raise_error
+      it 'must find by the engagement id' do
+        find_engagement = Hubspot::EngagementNote.find(engagement.id)
+        find_engagement.id.should eql engagement.id
+        find_engagement.body.should eql engagement.body
+      end
     end
-  end
 
-  describe '#destroy!' do
-    cassette 'engagement_destroy'
+    describe '#destroy!' do
+      cassette 'engagement_call_destroy'
 
-    let(:engagement) {Hubspot::EngagementNote.create!(nil, 'test note') }
+      let(:engagement) { Hubspot::EngagementCall.create!(nil, 'test call', 0) }
 
-    it 'should remove from hubspot' do
-      expect(Hubspot::Engagement.find(engagement.id)).to_not be_nil
+      it 'should remove from hubspot' do
+        expect(Hubspot::Engagement.find(engagement.id)).to_not be_nil
 
-      expect(engagement.destroy!).to be_true
-      expect(engagement.destroyed?).to be_true
+        expect(engagement.destroy!).to be_true
+        expect(engagement.destroyed?).to be_true
 
-      expect(Hubspot::Engagement.find(engagement.id)).to be_nil
+        expect(Hubspot::Engagement.find(engagement.id)).to be_nil
+      end
     end
   end
 end


### PR DESCRIPTION
Create Call Engagements.

Note that the API changed and trying to get an inexisting Engagement doesn't respond with a 404 anymore, but with an empty body.
[Example](https://api.hubapi.com/engagements/v1/engagements/THIS_ID_DOESNT_EXISTS?hapikey=demo)

So I adapted `Engagement.find` and rebuilt the VCR cassette.