### PR TITLE
Fix overwriting passed in property options

### DIFF
--- a/lib/hubspot/properties.rb
+++ b/lib/hubspot/properties.rb
@@ -8,13 +8,17 @@ module Hubspot
       valid_types:       %w(string number bool datetime enumeration),
       options:           %w(description value label hidden displayOrder)
     }
+    DEFAULT_PROPERTY = 'email'
 
     class << self
       # TODO: properties can be set as configuration
       # TODO: find the way how to set a list of Properties + merge same property key if present from opts
       def add_default_parameters(opts={})
-        properties = 'email'
-        opts.merge(property: properties)
+        if opts.keys.map(&:to_s).include? 'property'
+          opts
+        else
+          opts.merge(property: DEFAULT_PROPERTY)
+        end
       end
 
       def all(path, opts={}, filter={})

--- a/spec/lib/hubspot/company_properties_spec.rb
+++ b/spec/lib/hubspot/company_properties_spec.rb
@@ -1,8 +1,16 @@
 describe Hubspot::CompanyProperties do
   describe '.add_default_parameters' do
-    subject { Hubspot::CompanyProperties.add_default_parameters({}) }
+    let(:opts) { {} }
+    subject { Hubspot::CompanyProperties.add_default_parameters(opts) }
     context 'default parameters' do
-      its([:property]) { should == 'email' }
+      context 'without property parameter' do
+        its([:property]) { should == 'email' }
+      end
+
+      context 'with property parameter' do
+        let(:opts) { {property: 'name' } }
+        its([:property]) { should == 'name'}
+      end
     end
   end
 

--- a/spec/lib/hubspot/contact_properties_spec.rb
+++ b/spec/lib/hubspot/contact_properties_spec.rb
@@ -1,8 +1,16 @@
 describe Hubspot::ContactProperties do
   describe '.add_default_parameters' do
-    subject { Hubspot::ContactProperties.add_default_parameters({}) }
+    let(:opts) { {} }
+    subject { Hubspot::ContactProperties.add_default_parameters(opts) }
     context 'default parameters' do
-      its([:property]) { should == 'email' }
+      context 'without property parameter' do
+        its([:property]) { should == 'email' }
+      end
+
+      context 'with property parameter' do
+        let(:opts) { {property: 'firstname' } }
+        its([:property]) { should == 'firstname'}
+      end
     end
   end
 

--- a/spec/lib/hubspot/deal_properties_spec.rb
+++ b/spec/lib/hubspot/deal_properties_spec.rb
@@ -1,8 +1,16 @@
 describe Hubspot::DealProperties do
   describe '.add_default_parameters' do
-    subject { Hubspot::DealProperties.add_default_parameters({}) }
+    let(:opts) { {} }
+    subject { Hubspot::DealProperties.add_default_parameters(opts) }
     context 'default parameters' do
-      its([:property]) { should == 'email' }
+      context 'without property parameter' do
+        its([:property]) { should == 'email' }
+      end
+
+      context 'with property parameter' do
+        let(:opts) { {property: 'dealname' } }
+        its([:property]) { should == 'dealname'}
+      end
     end
   end
 


### PR DESCRIPTION
Properties.add_default_parameters was overwriting any passed in `property` key in the `opts` hash with the value `'email'`. This changes that so that `property: 'email'` will be set only if no `property` key already exists in the `opts` hash.

This should fix #61.