### PR TITLE
Return Hubspot::Contact objects for paging calls

### DIFF
--- a/lib/hubspot/contact.rb
+++ b/lib/hubspot/contact.rb
@@ -43,7 +43,8 @@ module Hubspot
         end
 
         response = Hubspot::Connection.get_json(path, opts)
-        paged ? response : response['contacts'].map { |c| new(c) }
+        response['contacts'].map! { |c| new(c) }
+        paged ? response : response['contacts']
       end
 
       # TODO: create or update a contact

--- a/lib/hubspot/contact_list.rb
+++ b/lib/hubspot/contact_list.rb
@@ -85,7 +85,7 @@ module Hubspot
         opts[:list_id] = @id
 
         response = Hubspot::Connection.get_json(path, Hubspot::ContactProperties.add_default_parameters(opts))
-        @contacts = response['contacts'].map { |c| Hubspot::Contact.new(c) }
+        @contacts = response['contacts'].map! { |c| Hubspot::Contact.new(c) }
         paged ? response : @contacts
       else
         @contacts

--- a/spec/lib/hubspot/contact_list_spec.rb
+++ b/spec/lib/hubspot/contact_list_spec.rb
@@ -38,6 +38,18 @@ describe Hubspot::ContactList do
       expect(contact).to be_a(Hubspot::Contact)
     end
 
+    it 'returns by default 20 contact lists with paging data' do
+      contact_data = list.contacts({paged: true})
+      contacts = contact_data['contacts']
+
+      expect(contact_data).to have_key 'vid-offset'
+      expect(contact_data).to have_key 'has-more'
+
+      expect(contacts.count).to eql 20
+      contact = contacts.first
+      expect(contact).to be_a(Hubspot::Contact)
+    end
+
     it 'add default properties to the contacts returned' do
       contact = list.contacts.first
       expect(contact.email).to_not be_empty
@@ -86,7 +98,7 @@ describe Hubspot::ContactList do
     context 'all list types' do
       cassette 'find_all_lists'
 
-      it 'returns by defaut 20 contact lists' do
+      it 'returns by default 20 contact lists' do
         lists = Hubspot::ContactList.all
         expect(lists.count).to eql 20
 

--- a/spec/lib/hubspot/contact_spec.rb
+++ b/spec/lib/hubspot/contact_spec.rb
@@ -270,6 +270,9 @@ describe Hubspot::Contact do
         first = contacts.first
         last = contacts.last
 
+        expect(contact_data).to have_key 'vid-offset'
+        expect(contact_data).to have_key 'has-more'
+
         expect(first).to be_a Hubspot::Contact
         expect(first.vid).to eql 154835
         expect(first['firstname']).to eql 'HubSpot'


### PR DESCRIPTION
Based on changes in adimichele/hubspot-ruby#58 pull request

Unfortunately it fails the test (see below) because it returns Contacts as JSON instead of Hubspot::Contact. Probably it will be better to keep 'vid-offset' parameter and at the same time initialize Contacts as they should be.

     Hubspot::Contact.all all contacts must get the contacts list with paging data
     Failure/Error: expect(first).to be_a Hubspot::Contact

       expected {"addedAt"=>1405347851360, "vid"=>154835, "canonical-vid"=>154835, "merged-vids"=>[], "portal-id"=>62515, "is-contact"=>true, "profile-token"=>"AO_T-mNJu56Masvy-UGew0va-sSwlbSvfM2QxK1J7sd52Qci-gZCHybsgFoIwqgvmHq9f01ywtMLA6vB131sFPFEpkGAvl-bvEJ0ZB9xzpVbPkYVRmHfFIU3q9WfOStV1IMYOqGL9wYl", "profile-url"=>"https://app.hubspot.com/contacts/62515/lists/public/contact/_AO_T-mNJu56Masvy-UGew0va-sSwlbSvfM2QxK1J7sd52Qci-gZCHybsgFoIwqgvmHq9f01ywtMLA6vB131sFPFEpkGAvl-bvEJ0ZB9xzpVbPkYVRmHfFIU3q9WfOStV1IMYOqGL9wYl/", "properties"=>{"firstname"=>{"value"=>"HubSpot"}, "lastmodifieddate"=>{"value"=>"1414183315068"}, "lastname"=>{"value"=>"Test"}}, "form-submissions"=>[{"conversion-id"=>"b18f9fd8-b8d3-49e5-898a-ac301fac93e9", "timestamp"=>1405347851180, "form-id"=>"b844ad5e-32bd-41e1-b0e6-ed990c5f3d1b", "portal-id"=>62515, "page-url"=>"http://demo.hubapi.com/your-stunning-headline-30", "page-title"=>"Your stunning headline!", "page-id"=>"324527", "title"=>"My New Form", "meta-data"=>[]}], "identity-profiles"=>[{"vid"=>154835, "saved-at-timestamp"=>1405347851237, "deleted-changed-timestamp"=>0, "identities"=>[{"type"=>"EMAIL", "value"=>"test@hubspot.com", "timestamp"=>1405347851180}, {"type"=>"LEAD_GUID", "value"=>"c8f20860-d3d6-4b57-b092-86a07cebdcbc", "timestamp"=>1405347851237}]}], "merge-audits"=>[]} to be a kind of Hubspot::Contact

     # ./spec/lib/hubspot/contact_spec.rb:273:in `block (4 levels)
