### PR TITLE
Added OAuth support.

### DIFF
--- a/lib/hubspot-ruby.rb
+++ b/lib/hubspot-ruby.rb
@@ -18,6 +18,7 @@ require 'hubspot/deal_pipeline'
 require 'hubspot/deal_properties'
 require 'hubspot/owner'
 require 'hubspot/engagement'
+require 'hubspot/oauth'
 
 module Hubspot
   def self.configure(config={})

--- a/lib/hubspot/config.rb
+++ b/lib/hubspot/config.rb
@@ -4,7 +4,10 @@ require 'hubspot/connection'
 module Hubspot
   class Config
 
-    CONFIG_KEYS = [:hapikey, :base_url, :portal_id, :logger, :access_token]
+    CONFIG_KEYS = [
+      :hapikey, :base_url, :portal_id, :logger, :access_token, :client_id,
+      :client_secret, :redirect_uri
+    ]
     DEFAULT_LOGGER = Logger.new('/dev/null')
 
     class << self
@@ -17,6 +20,10 @@ module Hubspot
         @portal_id = config["portal_id"]
         @logger = config["logger"] || DEFAULT_LOGGER
         @access_token = config["access_token"]
+        @client_id = config["client_id"] if config["client_id"].present?
+        @client_secret = config["client_secret"] if config["client_secret"].present?
+        @redirect_uri = config["redirect_uri"] if config["redirect_uri"].present?
+
         unless access_token.present? ^ hapikey.present?
           Hubspot::ConfigurationError.new("You must provide either an access_token or an hapikey")
         end

--- a/lib/hubspot/config.rb
+++ b/lib/hubspot/config.rb
@@ -1,9 +1,10 @@
 require 'logger'
+require 'hubspot/connection'
 
 module Hubspot
   class Config
 
-    CONFIG_KEYS = [:hapikey, :base_url, :portal_id, :logger]
+    CONFIG_KEYS = [:hapikey, :base_url, :portal_id, :logger, :access_token]
     DEFAULT_LOGGER = Logger.new('/dev/null')
 
     class << self
@@ -14,7 +15,14 @@ module Hubspot
         @hapikey = config["hapikey"]
         @base_url = config["base_url"] || "https://api.hubapi.com"
         @portal_id = config["portal_id"]
-        @logger = config['logger'] || DEFAULT_LOGGER
+        @logger = config["logger"] || DEFAULT_LOGGER
+        @access_token = config["access_token"]
+        unless access_token.present? ^ hapikey.present?
+          Hubspot::ConfigurationError.new("You must provide either an access_token or an hapikey")
+        end
+        if access_token.present?
+          Hubspot::Connection.headers("Authorization" => "Bearer #{access_token}")
+        end
         self
       end
 
@@ -23,6 +31,8 @@ module Hubspot
         @base_url = "https://api.hubapi.com"
         @portal_id = nil
         @logger = DEFAULT_LOGGER
+        @access_token = nil
+        Hubspot::Connection.headers({})
       end
 
       def ensure!(*params)

--- a/lib/hubspot/connection.rb
+++ b/lib/hubspot/connection.rb
@@ -45,7 +45,11 @@ module Hubspot
       end
 
       def generate_url(path, params={}, options={})
-        Hubspot::Config.ensure! :hapikey
+        if Hubspot::Config.access_token.present?
+          options[:hapikey] = false
+        else
+          Hubspot::Config.ensure! :hapikey
+        end
         path = path.clone
         params = params.clone
         base_url = options[:base_url] || Hubspot::Config.base_url

--- a/lib/hubspot/oauth.rb
+++ b/lib/hubspot/oauth.rb
@@ -1,0 +1,46 @@
+require 'httparty'
+module Hubspot
+  class OAuth < Connection
+    include HTTParty
+    DEFAULT_OAUTH_HEADERS = {"Content-Type" => "application/x-www-form-urlencoded;charset=utf-8"}
+    class << self
+      def refresh(params)
+        params.stringify_keys!
+        no_parse = params.delete("no_parse") { false }
+        body = {
+          client_id: params["client_id"] || Hubspot::Config.client_id,
+          grant_type: "refresh_token",
+          client_secret: params["client_secret"] || Hubspot::Config.client_secret,
+          redirect_uri: params["redirect_uri"] || Hubspot::Config.redirect_uri,
+          refresh_token: params["refresh_token"]
+        }
+        response = post(oauth_url, body: body, headers: DEFAULT_OAUTH_HEADERS)
+        log_request_and_response oauth_url, response, body
+        raise(Hubspot::RequestError.new(response)) unless response.success?
+
+        no_parse ? response : response.parsed_response
+      end
+
+      def create(params)
+        params.stringify_keys!
+        no_parse = params.delete("no_parse") { false }
+        body = {
+          client_id: params["client_id"] || Hubspot::Config.client_id,
+          grant_type: "authorization_code",
+          client_secret: params["client_secret"] || Hubspot::Config.client_secret,
+          redirect_uri: params["redirect_uri"] || Hubspot::Config.redirect_uri,
+          code: params["code"]
+        }
+        response = post(oauth_url, body: body, headers: DEFAULT_OAUTH_HEADERS)
+        log_request_and_response oauth_url, response, body
+        raise(Hubspot::RequestError.new(response)) unless response.success?
+
+        no_parse ? response : response.parsed_response
+      end
+
+      def oauth_url
+        oauth_url = Hubspot::Config.base_url + "/oauth/v1/token"
+      end
+    end
+  end
+end


### PR DESCRIPTION
- This commit lets the user pass an "access_token" to Hubspot.configure. At that point,
if an access token is passed, we set default headers on the Connection class, and this supports OAuth.

- I added a check in the get_url method which will not set an API key if an access token is present. This is required. Otherwise, Hubspot will fail the request, thinking that the api key was the intended auth method, but that the key was blank.

- I added an OAuth class to do simple creating/refreshing of the OAuth access tokens. For convenience here, I also added several of the params (like client id, and client secret) to the Hubspot.config method.

This has no tests yet. I've tested locally, but mainly looking to get your (@adimichele) thoughts to see if this direction seems acceptable, and if it's worth adding tests to this PR. If so, what level of tests do you think would work?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/adimichele/hubspot-ruby/70)
<!-- Reviewable:end -->
