### PR TITLE
Add list memberships to attribute accessors

### DIFF
--- a/lib/hubspot/contact.rb
+++ b/lib/hubspot/contact.rb
@@ -144,12 +144,13 @@ module Hubspot
     end
 
     attr_reader :properties, :vid, :is_new
-    attr_reader :is_contact
+    attr_reader :is_contact, :list_memberships
 
     def initialize(response_hash)
       props = response_hash['properties']
       @properties = Hubspot::Utils.properties_to_hash(props) unless props.blank?
       @is_contact = response_hash["is-contact"]
+      @list_memberships = response_hash["list-memberships"]
       @vid = response_hash['vid']
     end
 

--- a/lib/hubspot/contact.rb
+++ b/lib/hubspot/contact.rb
@@ -150,7 +150,7 @@ module Hubspot
       props = response_hash['properties']
       @properties = Hubspot::Utils.properties_to_hash(props) unless props.blank?
       @is_contact = response_hash["is-contact"]
-      @list_memberships = response_hash["list-memberships"]
+      @list_memberships = response_hash["list-memberships"] || []
       @vid = response_hash['vid']
     end
 


### PR DESCRIPTION
Contacts only return the properties portion of the hash from Hubspot.  It would be nice to be able to access the list-memberships so that it is easier to keep your application in sync with the lists a user belongs to in Hubspot.  