### PR TITLE
Form body should be URL encoded

### DIFF
--- a/lib/hubspot/connection.rb
+++ b/lib/hubspot/connection.rb
@@ -97,7 +97,8 @@ module Hubspot
 
     def self.submit(path, opts)
       url = generate_url(path, opts[:params], { base_url: 'https://forms.hubspot.com', hapikey: false })
-      post(url, body: opts[:body], headers: { 'Content-Type' => 'application/x-www-form-urlencoded' })
+      params = CGI.escape(opts[:body].map{|k,v| "#{k}=#{v}"}.join("&"))
+      post(url, body: params, headers: { 'Content-Type' => 'application/x-www-form-urlencoded' })
     end
   end
 end


### PR DESCRIPTION
HubSpot form API states the following:

"Please Note All parameters must be URL encoded before being passed through the API, including the hs_context parameter."

If it's not encoded and request contains URL unsafe characters, it silently fails to submit by creating empty fields.