### PR TITLE
Add date as valid property type in order to allow creating it through API request

### DIFF
--- a/lib/hubspot/properties.rb
+++ b/lib/hubspot/properties.rb
@@ -5,7 +5,7 @@ module Hubspot
       group_field_names: %w(name displayName displayOrder properties),
       field_names:       %w(name groupName description fieldType formField type displayOrder label options showCurrencySymbol),
       valid_field_types: %w(textarea select text date file number radio checkbox booleancheckbox),
-      valid_types:       %w(string number bool datetime enumeration),
+      valid_types:       %w(string number bool date datetime enumeration),
       options:           %w(description value label hidden displayOrder)
     }
     DEFAULT_PROPERTY = 'email'


### PR DESCRIPTION
Hello Team,

This PR is to allow creating property with datatype as `date` through API request. This is in refernce  to issue - https://github.com/adimichele/hubspot-ruby/issues/69

Please review and suggest.

Thanks