### PR TITLE
Add spec and fixture for Deal.find_by_company method

### DIFF
--- a/spec/fixtures/vcr_cassettes/deal_find_by_company.yml
+++ b/spec/fixtures/vcr_cassettes/deal_find_by_company.yml
@@ -1,0 +1,136 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.hubapi.com/companies/v2/companies/?hapikey=demo
+    body:
+      encoding: UTF-8
+      string: '{"properties":[{"name":"name","value":"Test Company"}]}'
+    headers:
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '800'
+      Date:
+      - Thu, 02 Nov 2017 00:39:01 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"portalId":62515,"companyId":592416090,"isDeleted":false,"properties":{"hs_lastmodifieddate":{"value":"1509583141275","timestamp":1509583141275,"source":"CALCULATED","sourceId":null,"versions":[{"name":"hs_lastmodifieddate","value":"1509583141275","timestamp":1509583141275,"source":"CALCULATED","sourceVid":[]}]},"name":{"value":"Test
+        Company","timestamp":1509583141275,"source":"API","sourceId":null,"versions":[{"name":"name","value":"Test
+        Company","timestamp":1509583141275,"source":"API","sourceVid":[]}]},"createdate":{"value":"1509583141275","timestamp":1509583141275,"source":"API","sourceId":"API","versions":[{"name":"createdate","value":"1509583141275","timestamp":1509583141275,"sourceId":"API","source":"API","sourceVid":[]}]}},"additionalDomains":[],"stateChanges":[],"mergeAudits":[]}'
+    http_version: 
+  recorded_at: Thu, 02 Nov 2017 00:39:01 GMT
+- request:
+    method: post
+    uri: https://api.hubapi.com/deals/v1/deal?hapikey=demo
+    body:
+      encoding: UTF-8
+      string: '{"portalId":62515,"associations":{"associatedCompanyIds":[592416090],"associatedVids":[27136]},"properties":[{"name":"amount","value":"30"}]}'
+    headers:
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Content-Length:
+      - '1328'
+      Date:
+      - Thu, 02 Nov 2017 00:39:01 GMT
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"portalId":62515,"dealId":213404277,"isDeleted":false,"associations":{"associatedVids":[],"associatedCompanyIds":[592416090],"associatedDealIds":[]},"associationCreateFailures":[{"association":{"fromObjectId":27136,"associationType":"CONTACT_TO_DEAL","toObjectId":213404277,"associationCategory":"HUBSPOT_DEFINED","associationTypeId":4,"timestamp":null},"failReason":"INVALID_OBJECT_IDS","message":"CONTACT=27136
+        is not valid"}],"properties":{"amount":{"value":"30","timestamp":1509583141407,"source":"API","sourceId":null,"versions":[{"name":"amount","value":"30","timestamp":1509583141407,"source":"API","sourceVid":[]}]},"hs_lastmodifieddate":{"value":"1509583141407","timestamp":1509583141407,"source":"CALCULATED","sourceId":null,"versions":[{"name":"hs_lastmodifieddate","value":"1509583141407","timestamp":1509583141407,"source":"CALCULATED","sourceVid":[]}]},"hs_createdate":{"value":"1509583141407","timestamp":1509583141407,"source":"API","sourceId":null,"versions":[{"name":"hs_createdate","value":"1509583141407","timestamp":1509583141407,"source":"API","sourceVid":[]}]},"createdate":{"value":"1509583141407","timestamp":1509583141407,"source":"API","sourceId":null,"versions":[{"name":"createdate","value":"1509583141407","timestamp":1509583141407,"source":"API","sourceVid":[]}]}},"imports":[],"stateChanges":[]}'
+    http_version: 
+  recorded_at: Thu, 02 Nov 2017 00:39:01 GMT
+- request:
+    method: get
+    uri: https://api.hubapi.com/deals/v1/deal/associated/company/592416090?hapikey=demo
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Vary:
+      - Accept-Encoding
+      - user-agent
+      Date:
+      - Thu, 02 Nov 2017 00:39:01 GMT
+      Content-Length:
+      - '58'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"results":[213404277],"hasMore":false,"offset":213404277}'
+    http_version: 
+  recorded_at: Thu, 02 Nov 2017 00:39:01 GMT
+- request:
+    method: get
+    uri: https://api.hubapi.com/deals/v1/deal/213404277?hapikey=demo
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Vary:
+      - Accept-Encoding
+      - user-agent
+      Date:
+      - Thu, 02 Nov 2017 00:39:01 GMT
+      Content-Length:
+      - '1237'
+      Connection:
+      - keep-alive
+    body:
+      encoding: UTF-8
+      string: '{"portalId":62515,"dealId":213404277,"isDeleted":false,"associations":{"associatedVids":[],"associatedCompanyIds":[592416090],"associatedDealIds":[]},"properties":{"amount":{"value":"30","timestamp":1509583141407,"source":"API","sourceId":null,"versions":[{"name":"amount","value":"30","timestamp":1509583141407,"source":"API","sourceVid":[]}]},"hs_lastmodifieddate":{"value":"1509583141407","timestamp":1509583141407,"source":"CALCULATED","sourceId":null,"versions":[{"name":"hs_lastmodifieddate","value":"1509583141407","timestamp":1509583141407,"source":"CALCULATED","sourceVid":[]}]},"num_associated_contacts":{"value":"0","timestamp":0,"source":"CALCULATED","sourceId":null,"versions":[{"name":"num_associated_contacts","value":"0","source":"CALCULATED","sourceVid":[]}]},"hs_createdate":{"value":"1509583141407","timestamp":1509583141407,"source":"API","sourceId":null,"versions":[{"name":"hs_createdate","value":"1509583141407","timestamp":1509583141407,"source":"API","sourceVid":[]}]},"createdate":{"value":"1509583141407","timestamp":1509583141407,"source":"API","sourceId":null,"versions":[{"name":"createdate","value":"1509583141407","timestamp":1509583141407,"source":"API","sourceVid":[]}]}},"imports":[],"stateChanges":[]}'
+    http_version: 
+  recorded_at: Thu, 02 Nov 2017 00:39:01 GMT
+recorded_with: VCR 3.0.3

--- a/spec/lib/hubspot/deal_spec.rb
+++ b/spec/lib/hubspot/deal_spec.rb
@@ -1,7 +1,12 @@
 describe Hubspot::Deal do
+  let(:portal_id) { 62515 }
+  let(:company_id) { 8954037 }
+  let(:vid) { 27136 }
+  let(:amount) { '30' }
+
   let(:example_deal_hash) do
     VCR.use_cassette("deal_example") do
-      HTTParty.get("https://api.hubapi.com/deals/v1/deal/3?hapikey=demo&portalId=62515").parsed_response
+      HTTParty.get("https://api.hubapi.com/deals/v1/deal/3?hapikey=demo&portalId=#{portal_id}").parsed_response
     end
   end
 
@@ -10,27 +15,27 @@ describe Hubspot::Deal do
   describe "#initialize" do
     subject{ Hubspot::Deal.new(example_deal_hash) }
     it  { should be_an_instance_of Hubspot::Deal }
-    its (:portal_id) { should == 62515 }
+    its (:portal_id) { should == portal_id }
     its (:deal_id) { should == 3 }
   end
 
   describe ".create!" do
     cassette "deal_create"
-    subject { Hubspot::Deal.create!(62515, [8954037], [27136], {}) }
+    subject { Hubspot::Deal.create!(portal_id, [company_id], [vid], {}) }
     its(:deal_id)     { should_not be_nil }
-    its(:portal_id)   { should eql 62515 }
-    its(:company_ids) { should eql [8954037]}
-    its(:vids)        { should eql [27136]}
+    its(:portal_id)   { should eql portal_id }
+    its(:company_ids) { should eql [company_id]}
+    its(:vids)        { should eql [vid]}
   end
 
   describe ".find" do
     cassette "deal_find"
-    let(:deal) {Hubspot::Deal.create!(62515, [8954037], [27136], { amount: 30})}
+    let(:deal) {Hubspot::Deal.create!(portal_id, [company_id], [vid], { amount: amount})}
 
     it 'must find by the deal id' do
       find_deal = Hubspot::Deal.find(deal.deal_id)
       find_deal.deal_id.should eql deal.deal_id
-      find_deal.properties["amount"].should eql "30"
+      find_deal.properties["amount"].should eql amount
     end
   end
 
@@ -68,7 +73,7 @@ describe Hubspot::Deal do
   describe '#destroy!' do
     cassette 'destroy_deal'
 
-    let(:deal) {Hubspot::Deal.create!(62515, [8954037], [27136], {amount: 30})}
+    let(:deal) {Hubspot::Deal.create!(portal_id, [company_id], [vid], {amount: amount})}
 
     it 'should remove from hubspot' do
       pending

--- a/spec/lib/hubspot/deal_spec.rb
+++ b/spec/lib/hubspot/deal_spec.rb
@@ -39,6 +39,18 @@ describe Hubspot::Deal do
     end
   end
 
+  describe '.find_by_company' do
+    cassette 'deal_find_by_company'
+    let(:company) { Hubspot::Company.create!('Test Company') }
+    let(:deal) { Hubspot::Deal.create!(portal_id, [company.vid], [vid], { amount: amount }) }
+
+    it 'returns company deals' do
+      deals = Hubspot::Deal.find_by_company(company)
+      deals.first.deal_id.should eql deal.deal_id
+      deals.first.properties['amount'].should eql amount
+    end
+  end
+
   describe '.recent' do
     cassette 'find_all_recent_updated_deals'
 


### PR DESCRIPTION
The `Hubspot::Deal.find_by_company` method was missing tests and fixtures. This was my first time using VCR and my Ruby chops are a wee bit rusty, so please don't be shy in your reviews.