### PR TITLE
Retrieve attachments from engagement response if present

### DIFF
--- a/lib/hubspot/engagement.rb
+++ b/lib/hubspot/engagement.rb
@@ -14,12 +14,14 @@ module Hubspot
     attr_reader :id
     attr_reader :engagement
     attr_reader :associations
+    attr_reader :attachments
     attr_reader :metadata
 
     def initialize(response_hash)
 
       @engagement = response_hash["engagement"]
       @associations = response_hash["associations"]
+      @attachments = response_hash["attachments"]
       @metadata = response_hash["metadata"]
       @id = engagement["id"]
     end


### PR DESCRIPTION

Attachments were not originally present in engagements output. I'm exposing them here since they're in the response hash.

See more here : https://developers.hubspot.com/docs/methods/engagements/engagements-overview