### PR TITLE
Params in engagement update! wasn't being used and engagement was always

### DIFF
--- a/lib/hubspot/engagement.rb
+++ b/lib/hubspot/engagement.rb
@@ -92,9 +92,10 @@ module Hubspot
     # @return [Hubspot::Engagement] self
     def update!(params)
       data = {
-        engagement: engagement,
-        associations: associations,
-        metadata: metadata
+        engagement: params[:engagement]     || engagement,
+        associations: params[:associations] || associations,
+        attachments: params[:attachments]   || attachments,
+        metadata: params[:metadata]         || metadata
       }
 
       Hubspot::Connection.put_json(ENGAGEMENT_PATH, params: { engagement_id: id }, body: data)


### PR DESCRIPTION
If you look at engagement update function, the params weren't actually being used to perform the update. Fixed to allow passed in params to update engagement.