### PR TITLE
Allow form to be initialised and submit without needing to call to `find`

### DIFF
--- a/lib/hubspot/form.rb
+++ b/lib/hubspot/form.rb
@@ -88,7 +88,7 @@ module Hubspot
 
     def assign_properties(hash)
       @guid = hash['guid']
-      @fields = hash['formFieldGroups'].inject([]){ |result, fg| result | fg['fields'] }
+      @fields = (hash['formFieldGroups'] || []).inject([]) { |result, fg| result | fg['fields'] }
       @properties = hash
     end
   end

--- a/spec/lib/hubspot/form_spec.rb
+++ b/spec/lib/hubspot/form_spec.rb
@@ -142,6 +142,18 @@ describe Hubspot::Form do
         result.should be false
       end
     end
+
+    context 'when initializing Hubspot::Form directly' do
+      let(:form) { Hubspot::Form.new('guid' => '561d9ce9-bb4c-45b4-8e32-21cdeaa3a7f0') }
+
+      before { Hubspot.configure(hapikey: 'demo', portal_id: '62515') }
+
+      it 'returns true if the form submission is successful' do
+        params = {}
+        result = form.submit(params)
+        result.should be true
+      end
+    end
   end
 
   describe '#update!' do


### PR DESCRIPTION
Currently, if trying to initialise a Hubspot::Form then submit, you end up needing to also include `formFieldGroups` in the initialiser parameters. It would appear this should be optional for the purpose of Form initialisation when trying to submit.

The other alternative is to use the `find` class method but this seems somewhat unnecessary also (either the form exists and happy days, or it doesn't and an error will be raised when submitting).

This change allows the following use-case:

```
Hubspot::Form.new('guid' => 'my-form-guid').submit(my_form_hash)
```