### PR TITLE
Prevents :email being passed in :properties for create_or_update!

### DIFF
--- a/lib/hubspot/contact.rb
+++ b/lib/hubspot/contact.rb
@@ -69,13 +69,16 @@ module Hubspot
       def create_or_update!(contacts)
         query = contacts.map do |ch|
           contact_hash = ch.with_indifferent_access
-          contact_param = {
-            properties: Hubspot::Utils.hash_to_properties(contact_hash.except(:vid))
-          }
           if contact_hash[:vid]
-            contact_param.merge!(vid: contact_hash[:vid])
+            contact_param = {
+              vid: contact_hash[:vid],
+              properties: Hubspot::Utils.hash_to_properties(contact_hash.except(:vid))
+            }
           elsif contact_hash[:email]
-            contact_param.merge!(email: contact_hash[:email])
+            contact_param = {
+              email: contact_hash[:email],
+              properties: Hubspot::Utils.hash_to_properties(contact_hash.except(:email))
+            }
           else
             raise Hubspot::InvalidParams, 'expecting vid or email for contact'
           end


### PR DESCRIPTION
Fixes issue https://github.com/adimichele/hubspot-ruby/issues/108

-----

When two contacts are merged in Hubspot, their emails are merged into a
comma-separated list. This list allows the contact to be found through
either email.

However, if the createOrUpdate endpoint matches on one of these
contacts and only one of the emails is passed in the properties hash,
Hubspot will attempt to update the email field. When using the email as
the identifier for a given Contact in createOrUpdate, the email should
not be included in the properties hash.