### PR TITLE
add the ability to associate an engagement note with a deal id

### DIFF
--- a/lib/hubspot/engagement.rb
+++ b/lib/hubspot/engagement.rb
@@ -113,7 +113,7 @@ module Hubspot
     end
 
     class << self
-      def create!(contact_id, note_body, owner_id = nil)
+      def create!(contact_id, note_body, owner_id = nil, deal_id = nil)
         data = {
           engagement: {
             type: 'NOTE'
@@ -128,6 +128,8 @@ module Hubspot
 
         # if the owner id has been provided, append it to the engagement
         data[:engagement][:owner_id] = owner_id if owner_id
+        # if the deal id has been provided, associate the note with the deal
+        data[:associations][:dealIds] = [deal_id] if deal_id
 
         super(data)
       end


### PR DESCRIPTION
The Hubspot API allows an EngagementNote to be associated with a deal ID, but the option was missing from the EngagementNote.create!  method.  I added deal_id as an optional field to the method which should allow this gem to be backwards compatible.