### PR TITLE
[feat/company-all-with-offset] improve Get all companies with other information

### DIFF
--- a/lib/hubspot/company.rb
+++ b/lib/hubspot/company.rb
@@ -5,17 +5,17 @@ module Hubspot
   # {http://developers.hubspot.com/docs/methods/companies/companies-overview}
   #
   class Company
-    CREATE_COMPANY_PATH               = "/companies/v2/companies/"
-    RECENTLY_CREATED_COMPANIES_PATH   = "/companies/v2/companies/recent/created"
-    RECENTLY_MODIFIED_COMPANIES_PATH  = "/companies/v2/companies/recent/modified"
-    GET_COMPANY_BY_ID_PATH            = "/companies/v2/companies/:company_id"
-    GET_COMPANY_BY_DOMAIN_PATH        = "/companies/v2/domains/:domain/companies"
-    UPDATE_COMPANY_PATH               = "/companies/v2/companies/:company_id"
-    GET_COMPANY_CONTACT_VIDS_PATH     = "/companies/v2/companies/:company_id/vids"
-    ADD_CONTACT_TO_COMPANY_PATH       = "/companies/v2/companies/:company_id/contacts/:vid"
-    DESTROY_COMPANY_PATH              = "/companies/v2/companies/:company_id"
-    GET_COMPANY_CONTACTS_PATH         = "/companies/v2/companies/:company_id/contacts"
-    BATCH_UPDATE_PATH                 = "/companies/v1/batch-async/update"
+    CREATE_COMPANY_PATH              = "/companies/v2/companies/"
+    RECENTLY_CREATED_COMPANIES_PATH  = "/companies/v2/companies/recent/created"
+    RECENTLY_MODIFIED_COMPANIES_PATH = "/companies/v2/companies/recent/modified"
+    GET_COMPANY_BY_ID_PATH           = "/companies/v2/companies/:company_id"
+    GET_COMPANY_BY_DOMAIN_PATH       = "/companies/v2/domains/:domain/companies"
+    UPDATE_COMPANY_PATH              = "/companies/v2/companies/:company_id"
+    GET_COMPANY_CONTACT_VIDS_PATH    = "/companies/v2/companies/:company_id/vids"
+    ADD_CONTACT_TO_COMPANY_PATH      = "/companies/v2/companies/:company_id/contacts/:vid"
+    DESTROY_COMPANY_PATH             = "/companies/v2/companies/:company_id"
+    GET_COMPANY_CONTACTS_PATH        = "/companies/v2/companies/:company_id/contacts"
+    BATCH_UPDATE_PATH                = "/companies/v1/batch-async/update"
 
     class << self
       # Find all companies by created date (descending)

--- a/spec/live/companies_integration_spec.rb
+++ b/spec/live/companies_integration_spec.rb
@@ -19,6 +19,7 @@ describe "Companies API Live test", live: true do
     expect(company["name"]).to eql "Create Delete Test 2"
 
     Hubspot::Company.batch_update!([{objectId: company.vid, name: 'Batch Update'}])
+    sleep 0.5 # prevent bulk update hasn't finished propagation
     company = Hubspot::Company.find_by_id(company.vid)
 
     expect(company["name"]).to eql "Batch Update"


### PR DESCRIPTION
Add new method `#all_with_offset` to return not only results as response but also `hasMore` and `offset`, so it would be possible to get all companies. For instance

```ruby
response = Hubspot::Company.all_with_offset(count: 100)
while response['hasMore']
  # DO SOMETHING with response['results']
  response = Hubspot::Company.all_with_offset(count: 100, offset: response['offset'])
end
```