### PR TITLE
Prevent VCR from making unexpected HTTP requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,13 +132,27 @@ Hubspot::Deal.create!(nil, [company.vid], [contact.vid], pipeline: 'default', de
 
 ### Testing
 
-All tests can be run with `rake spec`. Isolate fast-running tests with `rake spec:quick`.
+This project uses [VCR] to test interactions with the HubSpot API.
+VCR records HTTP requests and replays them during future tests.
 
-GET requests are pretty easy to test with VCR, but for POST/PUT requests, you probably want to update verify the state
-of a live HubSpot instance. To do this, please add "live" tests to `spec/live/`, using the rspec label `live: true` in
-order to disable VCR.
+All tests can be run with `rake spec`.
 
-"Live" tests can be isolated with `rake spec:live`.
+Tests under the `live` directory do not use VCR and issue real network calls.
+Do not add tests to this directory as these tests are being migrated over to use
+VCR.
+
+By default, the VCR recording mode is set to `:none`, which allows recorded
+requests to be re-played but raises for any new request. This prevents the test
+suite from issuing unexpected HTTP requests.
+
+To add a new test or update a VCR recording, run the test with the `VCR_RECORD`
+environment variable:
+
+```sh
+VCR_RECORD=1 bundle exec rspec spec
+```
+
+[VCR]: https://github.com/vcr/vcr
 
 ## Disclaimer
 

--- a/spec/lib/hubspot/blog_spec.rb
+++ b/spec/lib/hubspot/blog_spec.rb
@@ -13,7 +13,7 @@ describe Hubspot do
   describe Hubspot::Blog do
     describe ".list" do
       it "returns a list of blogs" do
-        VCR.use_cassette("blog_list", record: :none) do
+        VCR.use_cassette("blog_list") do
           result = Hubspot::Blog.list
 
           assert_requested :get, hubspot_api_url("/content/api/v2/blogs?hapikey=demo")
@@ -25,7 +25,7 @@ describe Hubspot do
 
     describe ".find_by_id" do
       it "retrieves a blog by id" do
-        VCR.use_cassette("blog_list", record: :none) do
+        VCR.use_cassette("blog_list") do
           id = 351076997
           result = Hubspot::Blog.find_by_id(id)
 
@@ -58,7 +58,7 @@ describe Hubspot do
 
     describe "#posts" do
       it "returns published blog posts created in the last 2 months" do
-        VCR.use_cassette("blog_posts/all_blog_posts", record: :none) do
+        VCR.use_cassette("blog_posts/all_blog_posts") do
           blog_id = 123
           created_gt = timestamp_in_milliseconds(Time.now - 2.months)
           blog = Hubspot::Blog.new({ "id" => blog_id })
@@ -71,7 +71,7 @@ describe Hubspot do
       end
 
       it "includes given parameters in the request" do
-        VCR.use_cassette("blog_posts/filter_blog_posts", record: :none) do
+        VCR.use_cassette("blog_posts/filter_blog_posts") do
           blog_id = 123
           created_gt = timestamp_in_milliseconds(Time.now - 2.months)
           blog = Hubspot::Blog.new({ "id" => 123 })

--- a/spec/lib/hubspot/company_properties_spec.rb
+++ b/spec/lib/hubspot/company_properties_spec.rb
@@ -15,13 +15,13 @@ describe Hubspot::CompanyProperties do
   end
 
   let(:example_groups) do
-    VCR.use_cassette('groups_example', record: :once) do
+    VCR.use_cassette('groups_example') do
       HTTParty.get('https://api.hubapi.com/companies/v2/groups?hapikey=demo').parsed_response
     end
   end
 
   let(:example_properties) do
-    VCR.use_cassette('properties_example', record: :once) do
+    VCR.use_cassette('properties_example') do
       HTTParty.get('https://api.hubapi.com/companies/v2/properties?hapikey=demo').parsed_response
     end
   end

--- a/spec/lib/hubspot/company_spec.rb
+++ b/spec/lib/hubspot/company_spec.rb
@@ -1,11 +1,11 @@
 describe Hubspot::Contact do
   let(:example_company_hash) do
-    VCR.use_cassette("company_example", record: :none) do
+    VCR.use_cassette("company_example") do
       HTTParty.get("https://api.hubapi.com/companies/v2/companies/21827084?hapikey=demo").parsed_response
     end
   end
   let(:company_with_contacts_hash) do
-    VCR.use_cassette("company_with_contacts", record: :none) do
+    VCR.use_cassette("company_with_contacts") do
       HTTParty.get("https://api.hubapi.com/companies/v2/companies/115200636?hapikey=demo").parsed_response
     end
   end

--- a/spec/lib/hubspot/contact_list_spec.rb
+++ b/spec/lib/hubspot/contact_list_spec.rb
@@ -1,6 +1,6 @@
 describe Hubspot::ContactList do
   let(:example_contact_list_hash) do
-    VCR.use_cassette("contact_list_example", record: :none) do
+    VCR.use_cassette("contact_list_example") do
       HTTParty.get("https://api.hubapi.com/contacts/v1/lists/1?hapikey=demo").parsed_response
     end
   end
@@ -9,7 +9,7 @@ describe Hubspot::ContactList do
   let(:dynamic_list) { Hubspot::ContactList.all(dynamic: true, count: 1).first }
 
   let(:example_contact_hash) do
-    VCR.use_cassette("contact_example", record: :none) do
+    VCR.use_cassette("contact_example") do
       HTTParty.get("https://api.hubapi.com/contacts/v1/contact/email/testingapis@hubspot.com/profile?hapikey=demo").parsed_response
     end
   end

--- a/spec/lib/hubspot/contact_properties_spec.rb
+++ b/spec/lib/hubspot/contact_properties_spec.rb
@@ -15,13 +15,13 @@ describe Hubspot::ContactProperties do
   end
 
   let(:example_groups) do
-    VCR.use_cassette('groups_example', record: :once) do
+    VCR.use_cassette('groups_example') do
       HTTParty.get('https://api.hubapi.com/contacts/v2/groups?hapikey=demo').parsed_response
     end
   end
 
   let(:example_properties) do
-    VCR.use_cassette('properties_example', record: :once) do
+    VCR.use_cassette('properties_example') do
       HTTParty.get('https://api.hubapi.com/contacts/v2/properties?hapikey=demo').parsed_response
     end
   end

--- a/spec/lib/hubspot/contact_spec.rb
+++ b/spec/lib/hubspot/contact_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Hubspot::Contact do
   let(:example_contact_hash) do
-    VCR.use_cassette('contact_example', record: :none) do
+    VCR.use_cassette('contact_example') do
       HTTParty.get('https://api.hubapi.com/contacts/v1/contact/email/testingapis@hubspot.com/profile?hapikey=demo').parsed_response
     end
   end
@@ -54,7 +54,7 @@ RSpec.describe Hubspot::Contact do
   describe '.createOrUpdate' do
     context "when the contact already exists" do
       it "updates the contact" do
-        VCR.use_cassette("contacts/update_contact", record: :none) do
+        VCR.use_cassette("contacts/update_contact") do
           existing_contact = Hubspot::Contact.create!("contact@example.com")
           email = existing_contact.email
           new_email = "new_email@example.com"
@@ -73,7 +73,7 @@ RSpec.describe Hubspot::Contact do
 
     context "when the contact does not exist" do
       it "creates the contact" do
-        VCR.use_cassette("contacts/create_contact", record: :none) do
+        VCR.use_cassette("contacts/create_contact") do
           email = "new_contact@example.com"
           params = { firstname: "Leslie", lastname: "Knope" }
 
@@ -93,7 +93,7 @@ RSpec.describe Hubspot::Contact do
 
     context "with an invalid email" do
       it "raises an error" do
-        VCR.use_cassette("contact_create_or_update_invalid_email", record: :none) do
+        VCR.use_cassette("contact_create_or_update_invalid_email") do
           expect {
             Hubspot::Contact.createOrUpdate("not_an_email")
           }.to raise_error(Hubspot::RequestError)

--- a/spec/lib/hubspot/deal_properties_spec.rb
+++ b/spec/lib/hubspot/deal_properties_spec.rb
@@ -15,13 +15,13 @@ describe Hubspot::DealProperties do
   end
 
   let(:example_groups) do
-    VCR.use_cassette('deal_groups_example', record: :once) do
+    VCR.use_cassette('deal_groups_example') do
       HTTParty.get('https://api.hubapi.com/deals/v1/groups?hapikey=demo').parsed_response
     end
   end
 
   let(:example_properties) do
-    VCR.use_cassette('deal_properties_example', record: :once) do
+    VCR.use_cassette('deal_properties_example') do
       HTTParty.get('https://api.hubapi.com/deals/v1/properties?hapikey=demo').parsed_response
     end
   end

--- a/spec/lib/hubspot/form_spec.rb
+++ b/spec/lib/hubspot/form_spec.rb
@@ -1,7 +1,7 @@
 describe Hubspot::Form do
   let(:guid) { '78c2891f-ebdd-44c0-bd94-15c012bbbfbf' } # '561d9ce9-bb4c-45b4-8e32-21cdeaa3a7f0'
   let(:example_form_hash) do
-    VCR.use_cassette('form_example', record: :none) do
+    VCR.use_cassette('form_example') do
       HTTParty.get("https://api.hubapi.com#{Hubspot::Form::FORMS_PATH}/#{guid}/?hapikey=demo").parsed_response
     end
   end

--- a/spec/lib/hubspot/utils_spec.rb
+++ b/spec/lib/hubspot/utils_spec.rb
@@ -31,13 +31,13 @@ describe Hubspot::Utils do
 
   describe '.compare_property_lists for ContactProperties' do
     let(:example_groups) do
-      VCR.use_cassette('groups_example', record: :once) do
+      VCR.use_cassette('groups_example') do
         HTTParty.get('https://api.hubapi.com/contacts/v2/groups?hapikey=demo').parsed_response
       end
     end
 
     let(:example_properties) do
-      VCR.use_cassette('properties_example', record: :once) do
+      VCR.use_cassette('properties_example') do
         HTTParty.get('https://api.hubapi.com/contacts/v2/properties?hapikey=demo').parsed_response
       end
     end
@@ -80,13 +80,13 @@ describe Hubspot::Utils do
 
   describe '.compare_property_lists for DealProperties' do
     let(:example_groups) do
-      VCR.use_cassette('deal_groups_example', record: :once) do
+      VCR.use_cassette('deal_groups_example') do
         HTTParty.get('https://api.hubapi.com/deals/v1/groups?hapikey=demo').parsed_response
       end
     end
 
     let(:example_properties) do
-      VCR.use_cassette('deal_properties_example', record: :once) do
+      VCR.use_cassette('deal_properties_example') do
         HTTParty.get('https://api.hubapi.com/deals/v1/properties?hapikey=demo').parsed_response
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,16 +13,10 @@ end
 require 'rspec'
 require 'webmock/rspec'
 require 'hubspot-ruby'
-require 'vcr'
 
 # Requires supporting files with custom matchers and macros, etc,
 # in ./support/ and its subdirectories.
 Dir["#{RSPEC_ROOT}/support/**/*.rb"].each {|f| require f}
-
-VCR.configure do |c|
-  c.cassette_library_dir = "#{RSPEC_ROOT}/fixtures/vcr_cassettes"
-  c.hook_into :webmock
-end
 
 RSpec.configure do |config|
   config.mock_with :rr

--- a/spec/support/cassette_helper.rb
+++ b/spec/support/cassette_helper.rb
@@ -1,7 +1,7 @@
 module CassetteHelper
   def self.extended(base)
     base.around do |spec|
-      VCR.insert_cassette(_cassette, record: :new_episodes) if defined?(_cassette) && _cassette
+      VCR.insert_cassette(_cassette) if defined?(_cassette) && _cassette
       spec.run
       VCR.eject_cassette if defined?(_cassette) && _cassette
     end

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -1,0 +1,15 @@
+require "vcr"
+
+def vcr_record_mode
+  if ENV["VCR_RECORD"] == "1"
+    :new_episodes
+  else
+    :none
+  end
+end
+
+VCR.configure do |c|
+  c.cassette_library_dir = "#{RSPEC_ROOT}/fixtures/vcr_cassettes"
+  c.hook_into :webmock
+  c.default_cassette_options = { record: vcr_record_mode }
+end


### PR DESCRIPTION
Note to the Reviewer:
This PR will fail on Travis until PR #138 is merged. The fact that Travis is now failing because VCR is now raising an error when encountering new requests is a sign that this change is working 😸 


Summary:
VCR defaults to using the record mode `:once`, which allows HTTP
interactions to be recorded when a cassette file doesn't exist but
raises when the cassette does exist and an unexpected request is made.

This behavior is currently being overridden in the `CassetteHelper` as
the record mode is being set to `:new_episodes`, which always allows new
HTTP interactions.

This PR:
- Sets the default record mode to `:none` to ensure new HTTP requests
  are intentional.
- Exposes the env variable VCR_RECORD to facilitate recording new HTTP
  interactions or updating existing cassettes.
- Removes references to the VCR record mode in individual tests
- Removes setting the record mode in the `CassetteHelper`