### PR TITLE
Add HubSpot module alias

### DIFF
--- a/lib/hubspot-ruby.rb
+++ b/lib/hubspot-ruby.rb
@@ -28,3 +28,6 @@ module Hubspot
 
   require 'hubspot/railtie' if defined?(Rails)
 end
+
+# Alias the module for those looking to use the stylized name HubSpot
+HubSpot = Hubspot


### PR DESCRIPTION
There have been some requests to change the module name to use the stylized HubSpot name which is ultimately a large change for a small stylistic benefit. This change allows developers to use HubSpot or Hubspot without breaking backwards compatibility.