### PR TITLE
Require at least Ruby 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,5 @@ before_install: gem install bundler
 
 rvm:
   - 2.5
+  - 2.4
+  - 2.3

--- a/hubspot-ruby.gemspec
+++ b/hubspot-ruby.gemspec
@@ -11,6 +11,8 @@ Gem::Specification.new do |s|
   s.homepage = "http://github.com/adimichele/hubspot-ruby"
   s.summary = "hubspot-ruby is a wrapper for the HubSpot REST API"
 
+  s.required_ruby_version = ">= 2.3"
+
   # Add runtime dependencies here
   s.add_runtime_dependency "activesupport", ">=3.0.0"
   s.add_runtime_dependency "httparty", ">=0.10.0"


### PR DESCRIPTION
After updating the tests we now require at least Ruby 2.3, which is the oldest supported Ruby version.