### PR TITLE
Remove unused extension of Railtie to import rake tasks

### DIFF
--- a/lib/hubspot/railtie.rb
+++ b/lib/hubspot/railtie.rb
@@ -1,9 +1,0 @@
-require 'hubspot-ruby'
-require 'rails'
-module Hubspot
-  class Railtie < Rails::Railtie
-    rake_tasks do
-      spec = Gem::Specification.find_by_name('hubspot-ruby')
-    end
-  end
-end


### PR DESCRIPTION
Summary:
Previously, we were importing 'properties.rake' task for end users.
This file was renamed to 'hubspot.rake', which led to users encountering
the LoadError "cannot load such file" since the import referenced a file
that no longer existed.

Rather than add the import back to reference the correct file,
'hubspot.rake', this change removes the railtie extension as we discuss
the future of 'hubspot.rake' and if we wish to continue supporting it or
remove it.

** Update **
We discussed this change in Slack and we're hesitant to remove these tasks because we don't know if anyone is relying on them. The plan forward is to add a deprecation warning to these tasks and see if anyone cares.