### PR TITLE
bump version

### DIFF
--- a/hubspot-ruby.gemspec
+++ b/hubspot-ruby.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "hubspot-ruby"
-  s.version = "0.6.0"
+  s.version = "0.6.1"
   s.require_paths = ["lib"]
   s.authors = ["Andrew DiMichele", "Chris Bisnett"]
   s.description = "hubspot-ruby is a wrapper for the HubSpot REST API"


### PR DESCRIPTION
Summary:
This version bump includes a backwards compatibility fix to expose the
hubspot rake tasks to users and adds deprecation warnings.