### PR TITLE
bump version to 0.6.1

### DIFF
--- a/hubspot-ruby.gemspec
+++ b/hubspot-ruby.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "hubspot-ruby"
-  s.version = "0.6.0"
+  s.version = "0.6.1"
   s.require_paths = ["lib"]
   s.authors = ["Andrew DiMichele", "Chris Bisnett"]
   s.description = "hubspot-ruby is a wrapper for the HubSpot REST API"


### PR DESCRIPTION
Note to the Reviewer: This PR was reviewed and merged into v0-stable for the v0.6.1 gem release (PR #147 ). This is now being merged into master so the code lives in v0.6.1 and future versions.

Summary:
This version bump includes a backwards compatibility fix to expose the
hubspot rake tasks to users and adds deprecation warnings.