### PR TITLE
remove 'mock' in preparation of RSpec 3

### DIFF
--- a/hubspot-ruby.gemspec
+++ b/hubspot-ruby.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |s|
   # Add development-only dependencies here
   s.add_development_dependency("rake", "~> 11.0")
   s.add_development_dependency("rspec", "~> 2.0")
-  s.add_development_dependency("rr")
   s.add_development_dependency("webmock")
   s.add_development_dependency("vcr")
   s.add_development_dependency("rdoc")

--- a/spec/fixtures/vcr_cassettes/contact_list/add_contact_to_dynamic_list.yml
+++ b/spec/fixtures/vcr_cassettes/contact_list/add_contact_to_dynamic_list.yml
@@ -1,0 +1,163 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.hubapi.com/contacts/v1/contact?hapikey=demo
+    body:
+      encoding: UTF-8
+      string: '{"properties":[{"property":"email","value":"email@example.com"}]}'
+    headers:
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 02 Dec 2018 22:10:01 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=df2dae9392b5010f24ce0c6f4a3f3ed231543788600; expires=Mon, 02-Dec-19
+        22:10:00 GMT; path=/; domain=.hubapi.com; HttpOnly
+      X-Trace:
+      - 2B43FA850FC151D94F8556970B69B238222C776CB8000000000000000000
+      X-Hubspot-Ratelimit-Daily:
+      - '160000'
+      X-Hubspot-Ratelimit-Daily-Remaining:
+      - '130477'
+      X-Hubspot-Ratelimit-Secondly:
+      - '60'
+      X-Hubspot-Ratelimit-Secondly-Remaining:
+      - '59'
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 48311f0369215a4a-BOS
+    body:
+      encoding: UTF-8
+      string: '{"vid":10581574,"canonical-vid":10581574,"merged-vids":[],"portal-id":62515,"is-contact":true,"profile-token":"AO_T-mP5i0pt6uF1JCooUeUIKr8CK9aej2MUtvF4RNN3uH3K97Ql8ILgje_QHW0gS8Ofa550emxIbdjfwY1P0wrOng9zyoGCA2GDvO8ZTzOBqY20ZIuwUf-Et6TmtENJS0j4057-JC0Z","profile-url":"https://app.hubspot.com/contacts/62515/lists/public/contact/_AO_T-mP5i0pt6uF1JCooUeUIKr8CK9aej2MUtvF4RNN3uH3K97Ql8ILgje_QHW0gS8Ofa550emxIbdjfwY1P0wrOng9zyoGCA2GDvO8ZTzOBqY20ZIuwUf-Et6TmtENJS0j4057-JC0Z/","properties":{"email":{"value":"email@example.com","versions":[{"value":"email@example.com","source-type":"API","source-id":null,"source-label":null,"timestamp":1543788600895,"selected":false}]}},"form-submissions":[],"list-memberships":[],"identity-profiles":[{"vid":10581574,"is-deleted":false,"is-contact":false,"pointer-vid":0,"previous-vid":0,"linked-vids":[],"saved-at-timestamp":0,"deleted-changed-timestamp":0,"identities":[{"type":"EMAIL","value":"email@example.com","timestamp":1543788600898,"is-primary":true,"source":"UNSPECIFIED"},{"type":"LEAD_GUID","value":"ec7f8124-08e0-4b3d-9285-586e666d0c65","timestamp":1543788600945,"source":"UNSPECIFIED"}]}],"merge-audits":[]}'
+    http_version: 
+  recorded_at: Sun, 02 Dec 2018 22:10:01 GMT
+- request:
+    method: post
+    uri: https://api.hubapi.com/contacts/v1/lists?hapikey=demo
+    body:
+      encoding: UTF-8
+      string: '{"name":"my-contacts-list","filters":[[{"operator":"EQ","property":"email","type":"string","value":"@hubspot.com"}]],"dynamic":true,"portal_id":null}'
+    headers:
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 02 Dec 2018 22:10:01 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d29afe2a6d0b1212cd807ca7ab0d8e14b1543788601; expires=Mon, 02-Dec-19
+        22:10:01 GMT; path=/; domain=.hubapi.com; HttpOnly
+      X-Trace:
+      - 2BF26B2EA4809343BAD497006C2EE87D2AB69E8F06000000000000000000
+      X-Hubspot-Ratelimit-Daily:
+      - '160000'
+      X-Hubspot-Ratelimit-Daily-Remaining:
+      - '130476'
+      X-Hubspot-Ratelimit-Secondly:
+      - '60'
+      X-Hubspot-Ratelimit-Secondly-Remaining:
+      - '59'
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 48311f05fe145a62-BOS
+    body:
+      encoding: UTF-8
+      string: '{"dynamic":true,"internalListId":489105,"archived":false,"metaData":{"listReferencesCount":null,"processing":"INITIALIZING","lastSizeChangeAt":0,"lastProcessingStateChangeAt":1543788601337,"error":"","size":0},"filters":[[{"withinTimeMode":"PAST","filterFamily":"PropertyValue","type":"string","operator":"EQ","property":"email","value":"@hubspot.com"}]],"portalId":62515,"createdAt":1543788601337,"listId":488319,"listType":"DYNAMIC","updatedAt":1543788601337,"name":"my-contacts-list"}'
+    http_version: 
+  recorded_at: Sun, 02 Dec 2018 22:10:01 GMT
+- request:
+    method: post
+    uri: https://api.hubapi.com/contacts/v1/lists/488319/add?hapikey=demo
+    body:
+      encoding: UTF-8
+      string: '{"vids":[10581574]}'
+    headers:
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Date:
+      - Sun, 02 Dec 2018 22:10:02 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=dee038744ca0d471626f532bc5496913f1543788602; expires=Mon, 02-Dec-19
+        22:10:02 GMT; path=/; domain=.hubapi.com; HttpOnly
+      X-Trace:
+      - 2BAF518307D2BC84A013A8B963D3DAC6B18364BC39000000000000000000
+      X-Hubspot-Ratelimit-Daily:
+      - '160000'
+      X-Hubspot-Ratelimit-Daily-Remaining:
+      - '130474'
+      X-Hubspot-Ratelimit-Secondly:
+      - '60'
+      X-Hubspot-Ratelimit-Secondly-Remaining:
+      - '59'
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 48311f0ae8f0ae08-BOS
+    body:
+      encoding: UTF-8
+      string: '{"status":"error","message":"Can not operate manually on a dynamic
+        list","correlationId":"88f0c6d3-c25d-4a19-bde0-9483a3df0f80","requestId":"779a4a68ba8696e6806567854da6c8b8"}'
+    http_version: 
+  recorded_at: Sun, 02 Dec 2018 22:10:02 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/contact_lists/add_contact.yml
+++ b/spec/fixtures/vcr_cassettes/contact_lists/add_contact.yml
@@ -1,0 +1,262 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.hubapi.com/contacts/v1/contact?hapikey=demo
+    body:
+      encoding: UTF-8
+      string: '{"properties":[{"property":"email","value":"email@example.com"}]}'
+    headers:
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 02 Dec 2018 20:23:37 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d74806c81d02c610315dde09160db67ac1543782217; expires=Mon, 02-Dec-19
+        20:23:37 GMT; path=/; domain=.hubapi.com; HttpOnly
+      X-Trace:
+      - 2BB44C2E05C0B84F93487C6C0AB4AAFBDB7756DC3F000000000000000000
+      X-Hubspot-Ratelimit-Daily:
+      - '160000'
+      X-Hubspot-Ratelimit-Daily-Remaining:
+      - '133542'
+      X-Hubspot-Ratelimit-Secondly:
+      - '60'
+      X-Hubspot-Ratelimit-Secondly-Remaining:
+      - '59'
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4830832b58565a62-BOS
+    body:
+      encoding: UTF-8
+      string: '{"vid":10581124,"canonical-vid":10581124,"merged-vids":[],"portal-id":62515,"is-contact":true,"profile-token":"AO_T-mPX-dbBuZ72YRJWrafc2wEmHHNqPPLM87M8MFErPHkAKWCmLuwAisv2qYhb00LpETlLZCLJ0Y82qotgPybRVr3EllDmETLrtZQhXamCoZmB_5PAFxd_CKnAJtWc1bc9xjRxGbMW","profile-url":"https://app.hubspot.com/contacts/62515/lists/public/contact/_AO_T-mPX-dbBuZ72YRJWrafc2wEmHHNqPPLM87M8MFErPHkAKWCmLuwAisv2qYhb00LpETlLZCLJ0Y82qotgPybRVr3EllDmETLrtZQhXamCoZmB_5PAFxd_CKnAJtWc1bc9xjRxGbMW/","properties":{"email":{"value":"email@example.com","versions":[{"value":"email@example.com","source-type":"API","source-id":null,"source-label":null,"timestamp":1543782217522,"selected":false}]}},"form-submissions":[],"list-memberships":[],"identity-profiles":[{"vid":10581124,"is-deleted":false,"is-contact":false,"pointer-vid":0,"previous-vid":0,"linked-vids":[],"saved-at-timestamp":0,"deleted-changed-timestamp":0,"identities":[{"type":"EMAIL","value":"email@example.com","timestamp":1543782217525,"is-primary":true,"source":"UNSPECIFIED"},{"type":"LEAD_GUID","value":"d9878797-46eb-4330-ac5c-93fb409111e7","timestamp":1543782217535,"source":"UNSPECIFIED"}]}],"merge-audits":[]}'
+    http_version: 
+  recorded_at: Sun, 02 Dec 2018 20:23:38 GMT
+- request:
+    method: post
+    uri: https://api.hubapi.com/contacts/v1/lists?hapikey=demo
+    body:
+      encoding: UTF-8
+      string: '{"name":"my-contacts-list","dynamic":false,"portal_id":null}'
+    headers:
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 02 Dec 2018 20:23:38 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=dd7eed4f4d5120e89f31a3eec042f331c1543782218; expires=Mon, 02-Dec-19
+        20:23:38 GMT; path=/; domain=.hubapi.com; HttpOnly
+      X-Trace:
+      - 2B8B74DB8F01105205D1E8264EF6582A6E12C452FA000000000000000000
+      X-Hubspot-Ratelimit-Daily:
+      - '160000'
+      X-Hubspot-Ratelimit-Daily-Remaining:
+      - '133541'
+      X-Hubspot-Ratelimit-Secondly:
+      - '60'
+      X-Hubspot-Ratelimit-Secondly-Remaining:
+      - '59'
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 48308330cafb5a4a-BOS
+    body:
+      encoding: UTF-8
+      string: '{"dynamic":false,"internalListId":489085,"archived":false,"metaData":{"listReferencesCount":null,"processing":"DONE","lastSizeChangeAt":0,"lastProcessingStateChangeAt":1543782218434,"error":"","size":0},"filters":[],"portalId":62515,"createdAt":1543782218434,"listId":488299,"listType":"STATIC","updatedAt":1543782218434,"name":"my-contacts-list"}'
+    http_version: 
+  recorded_at: Sun, 02 Dec 2018 20:23:38 GMT
+- request:
+    method: post
+    uri: https://api.hubapi.com/contacts/v1/lists/488299/add?hapikey=demo
+    body:
+      encoding: UTF-8
+      string: '{"vids":[10581124]}'
+    headers:
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 02 Dec 2018 20:23:39 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d2da8c7e6e2d5a30d09ed55a5a30ec9bc1543782218; expires=Mon, 02-Dec-19
+        20:23:38 GMT; path=/; domain=.hubapi.com; HttpOnly
+      X-Trace:
+      - 2B89F4BEE69A8B7AE6B303560B16ECE45CCBD255F4000000000000000000
+      X-Hubspot-Ratelimit-Daily:
+      - '160000'
+      X-Hubspot-Ratelimit-Daily-Remaining:
+      - '133540'
+      X-Hubspot-Ratelimit-Secondly:
+      - '60'
+      X-Hubspot-Ratelimit-Secondly-Remaining:
+      - '59'
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 48308334ba39ae38-BOS
+    body:
+      encoding: UTF-8
+      string: '{"updated":[10581124],"discarded":[],"invalidVids":[],"invalidEmails":[]}'
+    http_version: 
+  recorded_at: Sun, 02 Dec 2018 20:23:39 GMT
+- request:
+    method: delete
+    uri: https://api.hubapi.com/contacts/v1/contact/vid/10581124?hapikey=demo
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers: {}
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 02 Dec 2018 20:23:39 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d94e80116e9f18705b126356057e9cbe11543782219; expires=Mon, 02-Dec-19
+        20:23:39 GMT; path=/; domain=.hubapi.com; HttpOnly
+      X-Trace:
+      - 2BE5308535330188E5E1A9F55393FB9B2036757520000000000000000000
+      X-Hubspot-Ratelimit-Daily:
+      - '160000'
+      X-Hubspot-Ratelimit-Daily-Remaining:
+      - '133539'
+      X-Hubspot-Ratelimit-Secondly:
+      - '60'
+      X-Hubspot-Ratelimit-Secondly-Remaining:
+      - '58'
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 48308335ec055a56-BOS
+    body:
+      encoding: UTF-8
+      string: '{"vid":10581124,"deleted":true,"reason":"OK"}'
+    http_version: 
+  recorded_at: Sun, 02 Dec 2018 20:23:39 GMT
+- request:
+    method: delete
+    uri: https://api.hubapi.com/contacts/v1/lists/488299?hapikey=demo
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers: {}
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Sun, 02 Dec 2018 20:23:41 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d6780dfc3c4ef1ddd1b12149faaa3b1f71543782220; expires=Mon, 02-Dec-19
+        20:23:40 GMT; path=/; domain=.hubapi.com; HttpOnly
+      X-Trace:
+      - 2B143D8CBC9095E6A1C823DAB0C58683B1669A0537000000000000000000
+      X-Hubspot-Ratelimit-Daily:
+      - '160000'
+      X-Hubspot-Ratelimit-Daily-Remaining:
+      - '133538'
+      X-Hubspot-Ratelimit-Secondly:
+      - '60'
+      X-Hubspot-Ratelimit-Secondly-Remaining:
+      - '59'
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4830833f78975a68-BOS
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Sun, 02 Dec 2018 20:23:41 GMT
+recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/contact_lists/add_existing_contact.yml
+++ b/spec/fixtures/vcr_cassettes/contact_lists/add_existing_contact.yml
@@ -1,0 +1,315 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.hubapi.com/contacts/v1/contact?hapikey=demo
+    body:
+      encoding: UTF-8
+      string: '{"properties":[{"property":"email","value":"email@example.com"}]}'
+    headers:
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 02 Dec 2018 21:01:30 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=dd47a4095b20cd6371c97bb3a80ca01f61543784489; expires=Mon, 02-Dec-19
+        21:01:29 GMT; path=/; domain=.hubapi.com; HttpOnly
+      X-Trace:
+      - 2BE005CFBCBE2C8246572148415853729C3D4D8C7E000000000000000000
+      X-Hubspot-Ratelimit-Daily:
+      - '160000'
+      X-Hubspot-Ratelimit-Daily-Remaining:
+      - '131530'
+      X-Hubspot-Ratelimit-Secondly:
+      - '60'
+      X-Hubspot-Ratelimit-Secondly-Remaining:
+      - '59'
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4830baa5ca4f5a44-BOS
+    body:
+      encoding: UTF-8
+      string: '{"vid":10581374,"canonical-vid":10581374,"merged-vids":[],"portal-id":62515,"is-contact":true,"profile-token":"AO_T-mPYREUcwBVSIF6-nTET92vgF4dJOyMYQzFnEN29w-KbbT88fH6vtpXhvXBjazOgVEyH-w2dQ7n9_vFlRE7se_Uj38znGJT81Ivci3RFKAVpIEKhui2mD9YhQjzE08pdMnHyRIBc","profile-url":"https://app.hubspot.com/contacts/62515/lists/public/contact/_AO_T-mPYREUcwBVSIF6-nTET92vgF4dJOyMYQzFnEN29w-KbbT88fH6vtpXhvXBjazOgVEyH-w2dQ7n9_vFlRE7se_Uj38znGJT81Ivci3RFKAVpIEKhui2mD9YhQjzE08pdMnHyRIBc/","properties":{"email":{"value":"email@example.com","versions":[{"value":"email@example.com","source-type":"API","source-id":null,"source-label":null,"timestamp":1543784489923,"selected":false}]}},"form-submissions":[],"list-memberships":[],"identity-profiles":[{"vid":10581374,"is-deleted":false,"is-contact":false,"pointer-vid":0,"previous-vid":0,"linked-vids":[],"saved-at-timestamp":0,"deleted-changed-timestamp":0,"identities":[{"type":"EMAIL","value":"email@example.com","timestamp":1543784489927,"is-primary":true,"source":"UNSPECIFIED"},{"type":"LEAD_GUID","value":"5eacaf93-5754-4b7b-880a-c536bbc8a9ef","timestamp":1543784489939,"source":"UNSPECIFIED"}]}],"merge-audits":[]}'
+    http_version: 
+  recorded_at: Sun, 02 Dec 2018 21:01:30 GMT
+- request:
+    method: post
+    uri: https://api.hubapi.com/contacts/v1/lists?hapikey=demo
+    body:
+      encoding: UTF-8
+      string: '{"name":"my-contacts-list","dynamic":false,"portal_id":null}'
+    headers:
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 02 Dec 2018 21:01:30 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d44a4d25bfd44498421711c1e9eb276b71543784490; expires=Mon, 02-Dec-19
+        21:01:30 GMT; path=/; domain=.hubapi.com; HttpOnly
+      X-Trace:
+      - 2BCF6147C8F59544EDA33330AE528D7EAF0D2DB7E1000000000000000000
+      X-Hubspot-Ratelimit-Daily:
+      - '160000'
+      X-Hubspot-Ratelimit-Daily-Remaining:
+      - '131529'
+      X-Hubspot-Ratelimit-Secondly:
+      - '60'
+      X-Hubspot-Ratelimit-Secondly-Remaining:
+      - '59'
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4830baa94f3eae08-BOS
+    body:
+      encoding: UTF-8
+      string: '{"dynamic":false,"metaData":{"listReferencesCount":null,"processing":"DONE","lastSizeChangeAt":0,"lastProcessingStateChangeAt":1543784490515,"error":"","size":0},"filters":[],"internalListId":489103,"archived":false,"portalId":62515,"createdAt":1543784490515,"listId":488317,"listType":"STATIC","updatedAt":1543784490515,"name":"my-contacts-list"}'
+    http_version: 
+  recorded_at: Sun, 02 Dec 2018 21:01:30 GMT
+- request:
+    method: post
+    uri: https://api.hubapi.com/contacts/v1/lists/488317/add?hapikey=demo
+    body:
+      encoding: UTF-8
+      string: '{"vids":[10581374]}'
+    headers:
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 02 Dec 2018 21:01:31 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=dbc13cec85974c4f3d3864c0bb65007be1543784491; expires=Mon, 02-Dec-19
+        21:01:31 GMT; path=/; domain=.hubapi.com; HttpOnly
+      X-Trace:
+      - 2BFB8DC4B6889DFA791F82958EC5FC47A05FB020F3000000000000000000
+      X-Hubspot-Ratelimit-Daily:
+      - '160000'
+      X-Hubspot-Ratelimit-Daily-Remaining:
+      - '131528'
+      X-Hubspot-Ratelimit-Secondly:
+      - '60'
+      X-Hubspot-Ratelimit-Secondly-Remaining:
+      - '59'
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4830baacda4aae08-BOS
+    body:
+      encoding: UTF-8
+      string: '{"updated":[10581374],"discarded":[],"invalidVids":[],"invalidEmails":[]}'
+    http_version: 
+  recorded_at: Sun, 02 Dec 2018 21:01:31 GMT
+- request:
+    method: post
+    uri: https://api.hubapi.com/contacts/v1/lists/488317/add?hapikey=demo
+    body:
+      encoding: UTF-8
+      string: '{"vids":[10581374]}'
+    headers:
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 02 Dec 2018 21:01:31 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=dbc13cec85974c4f3d3864c0bb65007be1543784491; expires=Mon, 02-Dec-19
+        21:01:31 GMT; path=/; domain=.hubapi.com; HttpOnly
+      X-Trace:
+      - 2B0D1DE1FBBDA43DC911519CBB25A1107F7DC46D24000000000000000000
+      X-Hubspot-Ratelimit-Daily:
+      - '160000'
+      X-Hubspot-Ratelimit-Daily-Remaining:
+      - '131527'
+      X-Hubspot-Ratelimit-Secondly:
+      - '60'
+      X-Hubspot-Ratelimit-Secondly-Remaining:
+      - '58'
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4830baae3bdcae08-BOS
+    body:
+      encoding: UTF-8
+      string: '{"updated":[],"discarded":[10581374],"invalidVids":[],"invalidEmails":[]}'
+    http_version: 
+  recorded_at: Sun, 02 Dec 2018 21:01:31 GMT
+- request:
+    method: delete
+    uri: https://api.hubapi.com/contacts/v1/contact/vid/10581374?hapikey=demo
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers: {}
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Sun, 02 Dec 2018 21:01:31 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d38839d3f04477bc8ef63e0c598f471b31543784491; expires=Mon, 02-Dec-19
+        21:01:31 GMT; path=/; domain=.hubapi.com; HttpOnly
+      X-Trace:
+      - 2BC17FC4A9F9762AD7F8169BB86F249C0A73CDAE23000000000000000000
+      X-Hubspot-Ratelimit-Daily:
+      - '160000'
+      X-Hubspot-Ratelimit-Daily-Remaining:
+      - '131526'
+      X-Hubspot-Ratelimit-Secondly:
+      - '60'
+      X-Hubspot-Ratelimit-Secondly-Remaining:
+      - '57'
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4830baafcd0c5a2c-BOS
+    body:
+      encoding: UTF-8
+      string: '{"vid":10581374,"deleted":true,"reason":"OK"}'
+    http_version: 
+  recorded_at: Sun, 02 Dec 2018 21:01:31 GMT
+- request:
+    method: delete
+    uri: https://api.hubapi.com/contacts/v1/lists/488317?hapikey=demo
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers: {}
+  response:
+    status:
+      code: 204
+      message: No Content
+    headers:
+      Date:
+      - Sun, 02 Dec 2018 21:01:32 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d8aabd69b298beaa9b340cad1774658a71543784491; expires=Mon, 02-Dec-19
+        21:01:31 GMT; path=/; domain=.hubapi.com; HttpOnly
+      X-Trace:
+      - 2B33D206DF2D82DAEC37E4DC179F8DD47B83C712B2000000000000000000
+      X-Hubspot-Ratelimit-Daily:
+      - '160000'
+      X-Hubspot-Ratelimit-Daily-Remaining:
+      - '131525'
+      X-Hubspot-Ratelimit-Secondly:
+      - '60'
+      X-Hubspot-Ratelimit-Secondly-Remaining:
+      - '56'
+      Vary:
+      - Accept-Encoding
+      - Accept-Encoding
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 4830bab19d1eae38-BOS
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Sun, 02 Dec 2018 21:01:32 GMT
+recorded_with: VCR 4.0.0

--- a/spec/lib/hubspot-ruby_spec.rb
+++ b/spec/lib/hubspot-ruby_spec.rb
@@ -1,8 +1,12 @@
-describe Hubspot do
-  describe "#configure" do
-    it "delegates a call to Hubspot::Config.configure" do
-      mock(Hubspot::Config).configure({hapikey: "demo"})
-      Hubspot.configure hapikey: "demo"
+RSpec.describe Hubspot do
+  describe ".configure" do
+    it "delegates .configure to Hubspot::Config.configure" do
+      options = { hapikey: "demo" }
+      allow(Hubspot::Config).to receive(:configure).with(options)
+
+      Hubspot.configure(options)
+
+      expect(Hubspot::Config).to have_received(:configure).with(options)
     end
   end
 end

--- a/spec/lib/hubspot/connection_spec.rb
+++ b/spec/lib/hubspot/connection_spec.rb
@@ -1,44 +1,46 @@
 describe Hubspot::Connection do
-  before(:each) do
-    @url           = 'http://localhost:3000'
-    @http_response = mock('http_response')
+  before do
+    Hubspot.configure hapikey: 'fake'
   end
 
-  describe '.get_json' do
-    it 'delegates url format to Hubspot::Utils, call HTTParty get and returns response' do
-      @http_response.success? { true }
-      @http_response.parsed_response { {} }
-      @http_response.code { 200 }
-      @http_response.body { 'mocked response' }
+  describe ".get_json" do
+    it "returns the parsed response from the GET request" do
+      path = "/some/path"
+      body = { key: "value" }
 
-      mock(Hubspot::Connection).generate_url(@url, {}) { @url }
-      mock(Hubspot::Connection).get(@url, format: :json) { @http_response }
-      Hubspot::Connection.get_json(@url, {})
+      stub_request(:get, "https://api.hubapi.com/some/path?hapikey=fake").
+        to_return(status: 200, body: JSON.generate(body))
+
+      result = Hubspot::Connection.get_json(path, {})
+
+      expect(result).to eq({ "key" => "value" })
     end
   end
 
-  describe '.post_json' do
-    it 'delegates url format to Hubspot::Utils, call HTTParty post and returns response' do
-      @http_response.success? { true }
-      @http_response.parsed_response { {} }
-      @http_response.code { 200 }
-      @http_response.body { 'mocked response' }
+  describe ".post_json" do
+    it "returns the parsed response from the POST request" do
+      path = "/some/path"
+      body = { id: 1, name: "ABC" }
 
-      mock(Hubspot::Connection).generate_url(@url, {}) { @url }
-      mock(Hubspot::Connection).post(@url, body: "{}", headers: {"Content-Type"=>"application/json"}, format: :json) { @http_response }
-      Hubspot::Connection.post_json(@url, params: {}, body: {})
+      stub_request(:post, "https://api.hubapi.com/some/path?hapikey=fake&name=ABC").
+        to_return(status: 200, body: JSON.generate(body))
+
+      result = Hubspot::Connection.post_json(path, params: { name: "ABC" })
+
+      expect(result).to eq({ "id" => 1, "name" => "ABC" })
     end
   end
 
-  describe '.delete_json' do
-    it 'delegates url format to Hubspot::Utils, call HTTParty delete and returns response' do
-      @http_response.success? { true }
-      @http_response.code { 200 }
-      @http_response.body { 'mocked response' }
+  describe ".delete_json" do
+    it "returns the response from the DELETE request" do
+      path = "/some/path"
 
-      mock(Hubspot::Connection).generate_url(@url, {}) { @url }
-      mock(Hubspot::Connection).delete(@url, format: :json) { @http_response }
-      Hubspot::Connection.delete_json(@url, {})
+      stub_request(:delete, "https://api.hubapi.com/some/path?hapikey=fake").
+        to_return(status: 204, body: JSON.generate({}))
+
+      result = Hubspot::Connection.delete_json(path, {})
+
+      expect(result.code).to eq(204)
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,8 +19,6 @@ require 'hubspot-ruby'
 Dir["#{RSPEC_ROOT}/support/**/*.rb"].each {|f| require f}
 
 RSpec.configure do |config|
-  config.mock_with :rr
-
   config.after(:each) do
     Hubspot::Config.reset!
   end


### PR DESCRIPTION
Summary:
In preparation for upgrading to RSpec 3, this PR removes the use of the
test double library, [rr], in favor of RSpec's mocking framework. One of
the owners of the rr library has stated they do not have plans to
support RSpec 3. See the issue [Support for Rspec 3] for more details.

While RSpec 2 does expose a 'mock' method, RSpec 3 removes 'mock'
and 'stub' in favor of 'double' to create test doubles. Visit
the [RSpec changelog] for more details.

[rr]: https://github.com/rr/rr
[Support for RSpec 3]: https://github.com/rr/rr/issues/65
[RSpec changelog]:
https://github.com/rspec/rspec-mocks/blob/master/Changelog.md#300beta1--2013-11-07