### PR TITLE
Upgrade RSpec

### DIFF
--- a/hubspot-ruby.gemspec
+++ b/hubspot-ruby.gemspec
@@ -19,7 +19,8 @@ Gem::Specification.new do |s|
 
   # Add development-only dependencies here
   s.add_development_dependency("rake", "~> 11.0")
-  s.add_development_dependency("rspec", "~> 2.0")
+  s.add_development_dependency("rspec", "~> 3.8")
+  s.add_development_dependency("rspec-its", "~> 1.2")
   s.add_development_dependency("webmock")
   s.add_development_dependency("vcr")
   s.add_development_dependency("rdoc")

--- a/spec/fixtures/vcr_cassettes/destroy_deal.yml
+++ b/spec/fixtures/vcr_cassettes/destroy_deal.yml
@@ -2,118 +2,10 @@
 http_interactions:
 - request:
     method: post
-    uri: https://api.hubapi.com/deals/v1/deal?hapikey=demo&portalId=62515
-    body:
-      encoding: UTF-8
-      string: '{"portalId":62515,"associations":{"associatedCompanyIds":[8954037],"associatedVids":[27136]},"properties":[{"name":"amount","value":30}]}'
-    headers:
-      Content-Type:
-      - application/json
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Access-Control-Allow-Credentials:
-      - 'false'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 09 Jan 2015 19:34:49 GMT
-      Content-Length:
-      - '986'
-      Connection:
-      - keep-alive
-    body:
-      encoding: UTF-8
-      string: '{"portalId":62515,"dealId":1418749,"isDeleted":false,"associations":{"associatedVids":[27136],"associatedCompanyIds":[8954037],"associatedDealIds":[]},"properties":{"amount":{"value":"30","timestamp":1420832089249,"source":"API","sourceId":null,"versions":[{"name":"amount","value":"30","timestamp":1420832089249,"source":"API","sourceVid":[]}]},"hs_lastmodifieddate":{"value":"1420832089253","timestamp":1420832089253,"source":"CALCULATED","sourceId":null,"versions":[{"name":"hs_lastmodifieddate","value":"1420832089253","timestamp":1420832089253,"source":"CALCULATED","sourceVid":[]}]},"hs_createdate":{"value":"1420832089253","timestamp":1420832089253,"source":null,"sourceId":null,"versions":[{"name":"hs_createdate","value":"1420832089253","timestamp":1420832089253,"sourceVid":[]}]},"createdate":{"value":"1420832089253","timestamp":1420832089253,"source":null,"sourceId":null,"versions":[{"name":"createdate","value":"1420832089253","timestamp":1420832089253,"sourceVid":[]}]}}}'
-    http_version: 
-  recorded_at: Fri, 09 Jan 2015 19:34:49 GMT
-- request:
-    method: get
-    uri: https://api.hubapi.com/deals/v1/deal/1418749?hapikey=demo
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers: {}
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Access-Control-Allow-Credentials:
-      - 'false'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 09 Jan 2015 19:34:49 GMT
-      Content-Length:
-      - '1175'
-      Connection:
-      - keep-alive
-    body:
-      encoding: UTF-8
-      string: '{"portalId":62515,"dealId":1418749,"isDeleted":false,"associations":{"associatedVids":[27136],"associatedCompanyIds":[8954037],"associatedDealIds":[]},"properties":{"amount":{"value":"30","timestamp":1420832089260,"source":"API","sourceId":null,"versions":[{"name":"amount","value":"30","timestamp":1420832089260,"source":"API","sourceVid":[]}]},"hs_lastmodifieddate":{"value":"1420832089253","timestamp":1420832089260,"source":"CALCULATED","sourceId":null,"versions":[{"name":"hs_lastmodifieddate","value":"1420832089253","timestamp":1420832089260,"source":"CALCULATED","sourceVid":[]}]},"num_associated_contacts":{"value":"1","timestamp":0,"source":"CALCULATED","sourceId":null,"versions":[{"name":"num_associated_contacts","value":"1","source":"CALCULATED","sourceVid":[]}]},"hs_createdate":{"value":"1420832089253","timestamp":1420832089260,"source":null,"sourceId":null,"versions":[{"name":"hs_createdate","value":"1420832089253","timestamp":1420832089260,"sourceVid":[]}]},"createdate":{"value":"1420832089253","timestamp":1420832089260,"source":null,"sourceId":null,"versions":[{"name":"createdate","value":"1420832089253","timestamp":1420832089260,"sourceVid":[]}]}}}'
-    http_version: 
-  recorded_at: Fri, 09 Jan 2015 19:34:49 GMT
-- request:
-    method: delete
-    uri: https://api.hubapi.com/deals/v1/deal/1418749?hapikey=demo
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers: {}
-  response:
-    status:
-      code: 204
-      message: No Content
-    headers:
-      Access-Control-Allow-Credentials:
-      - 'false'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 09 Jan 2015 19:37:37 GMT
-      Connection:
-      - keep-alive
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Fri, 09 Jan 2015 19:37:37 GMT
-- request:
-    method: get
-    uri: https://api.hubapi.com/deals/v1/deal/1418749?hapikey=demo
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers: {}
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Access-Control-Allow-Credentials:
-      - 'false'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 09 Jan 2015 19:39:20 GMT
-      Content-Length:
-      - '101'
-      Connection:
-      - keep-alive
-    body:
-      encoding: UTF-8
-      string: '{"status":"error","message":"Deal does not exist","requestId":"31456253-ec6a-49a6-a170-6721fc030277"}'
-    http_version: 
-  recorded_at: Fri, 09 Jan 2015 19:39:20 GMT
-- request:
-    method: post
     uri: https://api.hubapi.com/deals/v1/deal?hapikey=demo
     body:
       encoding: UTF-8
-      string: '{"portalId":62515,"associations":{"associatedCompanyIds":[8954037],"associatedVids":[27136]},"properties":[{"name":"amount","value":30}]}'
+      string: '{"portalId":62515,"associations":{"associatedCompanyIds":[8954037],"associatedVids":[27136]},"properties":[{"name":"amount","value":"30"}]}'
     headers:
       Content-Type:
       - application/json
@@ -122,51 +14,47 @@ http_interactions:
       code: 200
       message: OK
     headers:
-      Access-Control-Allow-Credentials:
-      - 'false'
-      Content-Type:
-      - application/json; charset=UTF-8
       Date:
-      - Sun, 22 Feb 2015 16:16:53 GMT
-      Content-Length:
-      - '986'
+      - Mon, 03 Dec 2018 16:56:35 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Transfer-Encoding:
+      - chunked
       Connection:
       - keep-alive
-    body:
-      encoding: UTF-8
-      string: '{"portalId":62515,"dealId":2153873,"isDeleted":false,"associations":{"associatedVids":[27136],"associatedCompanyIds":[8954037],"associatedDealIds":[]},"properties":{"amount":{"value":"30","timestamp":1424621813768,"source":"API","sourceId":null,"versions":[{"name":"amount","value":"30","timestamp":1424621813768,"source":"API","sourceVid":[]}]},"hs_lastmodifieddate":{"value":"1424621813771","timestamp":1424621813771,"source":"CALCULATED","sourceId":null,"versions":[{"name":"hs_lastmodifieddate","value":"1424621813771","timestamp":1424621813771,"source":"CALCULATED","sourceVid":[]}]},"hs_createdate":{"value":"1424621813771","timestamp":1424621813771,"source":null,"sourceId":null,"versions":[{"name":"hs_createdate","value":"1424621813771","timestamp":1424621813771,"sourceVid":[]}]},"createdate":{"value":"1424621813771","timestamp":1424621813771,"source":null,"sourceId":null,"versions":[{"name":"createdate","value":"1424621813771","timestamp":1424621813771,"sourceVid":[]}]}}}'
-    http_version: 
-  recorded_at: Sun, 22 Feb 2015 16:16:53 GMT
-- request:
-    method: get
-    uri: https://api.hubapi.com/deals/v1/deal/2153873?hapikey=demo
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers: {}
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
+      Set-Cookie:
+      - __cfduid=d04b0a29b35afd150d008147989539f6a1543856195; expires=Tue, 03-Dec-19
+        16:56:35 GMT; path=/; domain=.hubapi.com; HttpOnly
+      X-Trace:
+      - 2BEC2314C3DF25672BC74A391F60A18D5E92386BD3000000000000000000
+      X-Hubspot-Ratelimit-Daily:
+      - '160000'
+      X-Hubspot-Ratelimit-Daily-Remaining:
+      - '131382'
+      X-Hubspot-Ratelimit-Secondly:
+      - '60'
+      X-Hubspot-Ratelimit-Secondly-Remaining:
+      - '59'
       Access-Control-Allow-Credentials:
       - 'false'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Sun, 22 Feb 2015 16:16:53 GMT
-      Content-Length:
-      - '1175'
-      Connection:
-      - keep-alive
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 483791468f3eae02-BOS
     body:
       encoding: UTF-8
-      string: '{"portalId":62515,"dealId":2153873,"isDeleted":false,"associations":{"associatedVids":[27136],"associatedCompanyIds":[8954037],"associatedDealIds":[]},"properties":{"amount":{"value":"30","timestamp":1424621813780,"source":"API","sourceId":null,"versions":[{"name":"amount","value":"30","timestamp":1424621813780,"source":"API","sourceVid":[]}]},"hs_lastmodifieddate":{"value":"1424621813771","timestamp":1424621813780,"source":"CALCULATED","sourceId":null,"versions":[{"name":"hs_lastmodifieddate","value":"1424621813771","timestamp":1424621813780,"source":"CALCULATED","sourceVid":[]}]},"num_associated_contacts":{"value":"1","timestamp":0,"source":"CALCULATED","sourceId":null,"versions":[{"name":"num_associated_contacts","value":"1","source":"CALCULATED","sourceVid":[]}]},"hs_createdate":{"value":"1424621813771","timestamp":1424621813780,"source":null,"sourceId":null,"versions":[{"name":"hs_createdate","value":"1424621813771","timestamp":1424621813780,"sourceVid":[]}]},"createdate":{"value":"1424621813771","timestamp":1424621813780,"source":null,"sourceId":null,"versions":[{"name":"createdate","value":"1424621813771","timestamp":1424621813780,"sourceVid":[]}]}}}'
+      string: '{"portalId":62515,"dealId":423241776,"isDeleted":false,"associations":{"associatedVids":[],"associatedCompanyIds":[],"associatedDealIds":[]},"associationCreateFailures":[{"association":{"fromObjectId":423241776,"toObjectId":27136,"associationCategory":"HUBSPOT_DEFINED","associationTypeId":3,"timestamp":null},"failReason":"INVALID_OBJECT_IDS","message":"CONTACT=27136
+        is not valid"},{"association":{"fromObjectId":423241776,"toObjectId":8954037,"associationCategory":"HUBSPOT_DEFINED","associationTypeId":5,"timestamp":null},"failReason":"INVALID_OBJECT_IDS","message":"COMPANY=8954037
+        is not valid"}],"properties":{"amount":{"value":"30","timestamp":1543856195636,"source":"API","sourceId":null,"versions":[{"name":"amount","value":"30","timestamp":1543856195636,"source":"API","sourceVid":[]}]},"hs_lastmodifieddate":{"value":"1543856195636","timestamp":1543856195636,"source":"CALCULATED","sourceId":null,"versions":[{"name":"hs_lastmodifieddate","value":"1543856195636","timestamp":1543856195636,"source":"CALCULATED","sourceVid":[]}]},"hs_createdate":{"value":"1543856195636","timestamp":1543856195636,"source":"API","sourceId":null,"versions":[{"name":"hs_createdate","value":"1543856195636","timestamp":1543856195636,"source":"API","sourceVid":[]}]},"createdate":{"value":"1543856195636","timestamp":1543856195636,"source":"API","sourceId":null,"versions":[{"name":"createdate","value":"1543856195636","timestamp":1543856195636,"source":"API","sourceVid":[]}]},"amount_in_home_currency":{"value":"30","timestamp":1543856195636,"source":"CALCULATED","sourceId":null,"versions":[{"name":"amount_in_home_currency","value":"30","timestamp":1543856195636,"source":"CALCULATED","sourceVid":[],"sourceMetadata":""}]}},"imports":[],"stateChanges":[]}'
     http_version: 
-  recorded_at: Sun, 22 Feb 2015 16:16:53 GMT
+  recorded_at: Mon, 03 Dec 2018 16:56:35 GMT
 - request:
     method: delete
-    uri: https://api.hubapi.com/deals/v1/deal/2153873?hapikey=demo
+    uri: https://api.hubapi.com/deals/v1/deal/423241776?hapikey=demo
     body:
       encoding: US-ASCII
       string: ''
@@ -176,46 +64,38 @@ http_interactions:
       code: 204
       message: No Content
     headers:
-      Access-Control-Allow-Credentials:
-      - 'false'
-      Content-Type:
-      - application/json; charset=UTF-8
       Date:
-      - Sun, 22 Feb 2015 16:20:04 GMT
+      - Mon, 03 Dec 2018 16:56:35 GMT
+      Content-Type:
+      - application/json;charset=utf-8
       Connection:
       - keep-alive
-    body:
-      encoding: UTF-8
-      string: ''
-    http_version: 
-  recorded_at: Sun, 22 Feb 2015 16:20:04 GMT
-- request:
-    method: get
-    uri: https://api.hubapi.com/deals/v1/deal/2153873?hapikey=demo
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers: {}
-  response:
-    status:
-      code: 404
-      message: Not Found
-    headers:
-      Access-Control-Allow-Credentials:
-      - 'false'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Sun, 22 Feb 2015 16:20:04 GMT
+      Set-Cookie:
+      - __cfduid=d50c30853122eae865af9480f4f1aff591543856195; expires=Tue, 03-Dec-19
+        16:56:35 GMT; path=/; domain=.hubapi.com; HttpOnly
       X-Trace:
-      - 1BF95B4C12411F9FF5CF3361D112DC37830B229B83FB82885400A1ABA9
-      Content-Length:
-      - '101'
-      Connection:
-      - keep-alive
+      - 2B79432B7EC59162004B71E135371704E3C440E023000000000000000000
+      X-Hubspot-Ratelimit-Daily:
+      - '160000'
+      X-Hubspot-Ratelimit-Daily-Remaining:
+      - '131381'
+      X-Hubspot-Ratelimit-Secondly:
+      - '60'
+      X-Hubspot-Ratelimit-Secondly-Remaining:
+      - '58'
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 48379147adb2ae2c-BOS
     body:
       encoding: UTF-8
-      string: '{"status":"error","message":"Deal does not exist","requestId":"0fa11d39-af49-4146-9a70-fdef574ab67b"}'
+      string: ''
     http_version: 
-  recorded_at: Sun, 22 Feb 2015 16:20:04 GMT
-recorded_with: VCR 2.4.0
+  recorded_at: Mon, 03 Dec 2018 16:56:35 GMT
+recorded_with: VCR 4.0.0

--- a/spec/lib/hubspot/company_properties_spec.rb
+++ b/spec/lib/hubspot/company_properties_spec.rb
@@ -1,4 +1,4 @@
-describe Hubspot::CompanyProperties do
+RSpec.describe Hubspot::CompanyProperties do
   describe '.add_default_parameters' do
     let(:opts) { {} }
     subject { Hubspot::CompanyProperties.add_default_parameters(opts) }
@@ -45,7 +45,7 @@ describe Hubspot::CompanyProperties do
 
         it 'should return properties for the specified group[s]' do
           response = Hubspot::CompanyProperties.all({}, { include: groups })
-          response.each { |p| expect(groups.include?(p['groupName'])).to be_true }
+          response.each { |p| expect(groups.include?(p['groupName'])).to be true }
         end
       end
 
@@ -54,7 +54,7 @@ describe Hubspot::CompanyProperties do
 
         it 'should return properties for the non-specified group[s]' do
           response = Hubspot::CompanyProperties.all({}, { exclude: groups })
-          response.each { |p| expect(groups.include?(p['groupName'])).to be_false }
+          response.each { |p| expect(groups.include?(p['groupName'])).to be false }
         end
       end
     end
@@ -158,7 +158,7 @@ describe Hubspot::CompanyProperties do
 
         it 'should return the specified groups' do
           response = Hubspot::CompanyProperties.groups({}, { include: groups })
-          response.each { |p| expect(groups.include?(p['name'])).to be_true }
+          response.each { |p| expect(groups.include?(p['name'])).to be true }
         end
       end
 
@@ -167,7 +167,7 @@ describe Hubspot::CompanyProperties do
 
         it 'should return groups that were not excluded' do
           response = Hubspot::CompanyProperties.groups({}, { exclude: groups })
-          response.each { |p| expect(groups.include?(p['name'])).to be_false }
+          response.each { |p| expect(groups.include?(p['name'])).to be false }
         end
       end
     end
@@ -186,7 +186,7 @@ describe Hubspot::CompanyProperties do
 
         it 'should return the valid parameters' do
           response = Hubspot::CompanyProperties.create_group!(params)
-          expect(Hubspot::CompanyProperties.same?(response, params)).to be_true
+          expect(Hubspot::CompanyProperties.same?(response, params)).to be true
         end
       end
 
@@ -198,7 +198,7 @@ describe Hubspot::CompanyProperties do
         it 'should return the valid parameters' do
           params['name'] = 'ff_group235'
           response       = Hubspot::CompanyProperties.create_group!(sub_params)
-          expect(Hubspot::CompanyProperties.same?(response, sub_params)).to be_true
+          expect(Hubspot::CompanyProperties.same?(response, sub_params)).to be true
         end
       end
     end
@@ -218,7 +218,7 @@ describe Hubspot::CompanyProperties do
           params['displayName'] = 'Test Group OneA'
 
           response = Hubspot::CompanyProperties.update_group!(params['name'], params)
-          expect(Hubspot::CompanyProperties.same?(response, params)).to be_true
+          expect(Hubspot::CompanyProperties.same?(response, params)).to be true
         end
       end
 

--- a/spec/lib/hubspot/company_spec.rb
+++ b/spec/lib/hubspot/company_spec.rb
@@ -234,16 +234,16 @@ describe Hubspot::Contact do
     cassette "company_destroy"
     let(:company){ Hubspot::Company.create!("newcompany_y_#{Time.now.to_i}@hsgem.com") }
     subject{ company.destroy! }
-    it { should be_true }
+    it { should be true }
     it "should be destroyed" do
       subject
-      company.destroyed?.should be_true
+      company.destroyed?.should be true
     end
     context "when the request is not successful" do
       let(:company){ Hubspot::Company.new({"vid" => "invalid", "properties" => {}})}
       it "raises an error" do
         expect{ subject }.to raise_error Hubspot::RequestError
-        company.destroyed?.should be_false
+        company.destroyed?.should be false
       end
     end
   end
@@ -278,7 +278,7 @@ describe Hubspot::Contact do
   describe "#destroyed?" do
     let(:company){ Hubspot::Company.new(example_company_hash) }
     subject{ company }
-    its(:destroyed?){ should be_false }
+    its(:destroyed?){ should be false }
   end
 
   describe "#contacts" do

--- a/spec/lib/hubspot/contact_list_spec.rb
+++ b/spec/lib/hubspot/contact_list_spec.rb
@@ -282,11 +282,11 @@ describe Hubspot::ContactList do
 
     let(:contact_list) { Hubspot::ContactList.create!({ name: "newcontactlist_#{Time.now.to_i}"}) }
     subject{ contact_list.destroy! }
-    it { should be_true }
+    it { should be true }
 
     it "should be destroyed" do
       subject
-      contact_list.destroyed?.should be_true
+      expect(contact_list).to be_destroyed
     end
   end
 

--- a/spec/lib/hubspot/contact_properties_spec.rb
+++ b/spec/lib/hubspot/contact_properties_spec.rb
@@ -45,7 +45,7 @@ describe Hubspot::ContactProperties do
 
         it 'should return properties for the specified group[s]' do
           response = Hubspot::ContactProperties.all({}, { include: groups })
-          response.each { |p| expect(groups.include?(p['groupName'])).to be_true }
+          response.each { |p| expect(groups.include?(p['groupName'])).to be true }
         end
       end
 
@@ -54,7 +54,7 @@ describe Hubspot::ContactProperties do
 
         it 'should return properties for the non-specified group[s]' do
           response = Hubspot::ContactProperties.all({}, { exclude: groups })
-          response.each { |p| expect(groups.include?(p['groupName'])).to be_false }
+          response.each { |p| expect(groups.include?(p['groupName'])).to be false }
         end
       end
     end
@@ -158,7 +158,7 @@ describe Hubspot::ContactProperties do
 
         it 'should return the specified groups' do
           response = Hubspot::ContactProperties.groups({}, { include: groups })
-          response.each { |p| expect(groups.include?(p['name'])).to be_true }
+          response.each { |p| expect(groups.include?(p['name'])).to be true }
         end
       end
 
@@ -167,7 +167,7 @@ describe Hubspot::ContactProperties do
 
         it 'should return groups that were not excluded' do
           response = Hubspot::ContactProperties.groups({}, { exclude: groups })
-          response.each { |p| expect(groups.include?(p['name'])).to be_false }
+          response.each { |p| expect(groups.include?(p['name'])).to be false }
         end
       end
     end
@@ -186,7 +186,7 @@ describe Hubspot::ContactProperties do
 
         it 'should return the valid parameters' do
           response = Hubspot::ContactProperties.create_group!(params)
-          expect(Hubspot::ContactProperties.same?(response, params)).to be_true
+          expect(Hubspot::ContactProperties.same?(response, params)).to be true
         end
       end
 
@@ -198,7 +198,7 @@ describe Hubspot::ContactProperties do
         it 'should return the valid parameters' do
           params['name'] = 'ff_group234'
           response       = Hubspot::ContactProperties.create_group!(sub_params)
-          expect(Hubspot::ContactProperties.same?(response, sub_params)).to be_true
+          expect(Hubspot::ContactProperties.same?(response, sub_params)).to be true
         end
       end
     end
@@ -218,7 +218,7 @@ describe Hubspot::ContactProperties do
           params['displayName'] = 'Test Group OneA'
 
           response = Hubspot::ContactProperties.update_group!(params['name'], params)
-          expect(Hubspot::ContactProperties.same?(response, params)).to be_true
+          expect(Hubspot::ContactProperties.same?(response, params)).to be true
         end
       end
 

--- a/spec/lib/hubspot/contact_spec.rb
+++ b/spec/lib/hubspot/contact_spec.rb
@@ -157,8 +157,11 @@ RSpec.describe Hubspot::Contact do
 
       it 'find lists of contacts' do
         emails = ['testingapis@hubspot.com', 'testingapisawesomeandstuff@hubspot.com']
-        contacts = Hubspot::Contact.find_by_email(emails)
-        pending
+        email_query_params = "email=#{emails.first}&email=#{emails.last}"
+
+        Hubspot::Contact.find_by_email(emails)
+
+        assert_requested :get, hubspot_api_url("/contacts/v1/contact/emails/batch?#{email_query_params}&hapikey=demo")
       end
     end
   end
@@ -402,16 +405,16 @@ RSpec.describe Hubspot::Contact do
     cassette 'contact_destroy'
     let(:contact){ Hubspot::Contact.create!("newcontact_y_#{Time.now.to_i}@hsgem.com") }
     subject{ contact.destroy! }
-    it { should be_true }
+    it { should be true }
     it 'should be destroyed' do
       subject
-      contact.destroyed?.should be_true
+      contact.destroyed?.should be true
     end
     context 'when the request is not successful' do
       let(:contact){ Hubspot::Contact.new({'vid' => 'invalid', 'properties' => {}})}
       it 'raises an error' do
         expect{ subject }.to raise_error Hubspot::RequestError
-        contact.destroyed?.should be_false
+        contact.destroyed?.should be false
       end
     end
   end
@@ -419,6 +422,6 @@ RSpec.describe Hubspot::Contact do
   describe '#destroyed?' do
     let(:contact){ Hubspot::Contact.new(example_contact_hash) }
     subject{ contact }
-    its(:destroyed?){ should be_false }
+    its(:destroyed?){ should be false }
   end
 end

--- a/spec/lib/hubspot/deal_properties_spec.rb
+++ b/spec/lib/hubspot/deal_properties_spec.rb
@@ -45,7 +45,7 @@ describe Hubspot::DealProperties do
 
         it 'should return properties for the specified group[s]' do
           response = Hubspot::DealProperties.all({}, { include: groups })
-          response.each { |p| expect(groups.include?(p['groupName'])).to be_true }
+          response.each { |p| expect(groups.include?(p['groupName'])).to be true }
         end
       end
 
@@ -54,7 +54,7 @@ describe Hubspot::DealProperties do
 
         it 'should return properties for the non-specified group[s]' do
           response = Hubspot::DealProperties.all({}, { exclude: groups })
-          response.each { |p| expect(groups.include?(p['groupName'])).to be_false }
+          response.each { |p| expect(groups.include?(p['groupName'])).to be false }
         end
       end
     end
@@ -110,7 +110,7 @@ describe Hubspot::DealProperties do
 
         it 'should return the valid parameters' do
           response = Hubspot::DealProperties.create!(params)
-          expect(Hubspot::DealProperties.same?(params, response)).to be_true
+          expect(Hubspot::DealProperties.same?(params, response)).to be true
         end
       end
     end
@@ -130,7 +130,7 @@ describe Hubspot::DealProperties do
           params['description'] = 'What is their favorite flavor?'
 
           response = Hubspot::DealProperties.update!(params['name'], params)
-          expect(Hubspot::DealProperties.same?(response, params)).to be_true
+          expect(Hubspot::DealProperties.same?(response, params)).to be true
         end
       end
     end
@@ -173,7 +173,7 @@ describe Hubspot::DealProperties do
 
         it 'should return the specified groups' do
           response = Hubspot::DealProperties.groups({}, { include: groups })
-          response.each { |p| expect(groups.include?(p['name'])).to be_true }
+          response.each { |p| expect(groups.include?(p['name'])).to be true }
         end
       end
 
@@ -182,7 +182,7 @@ describe Hubspot::DealProperties do
 
         it 'should return groups that were not excluded' do
           response = Hubspot::DealProperties.groups({}, { exclude: groups })
-          response.each { |p| expect(groups.include?(p['name'])).to be_false }
+          response.each { |p| expect(groups.include?(p['name'])).to be false }
         end
       end
     end
@@ -201,7 +201,7 @@ describe Hubspot::DealProperties do
 
         it 'should return the valid parameters' do
           response = Hubspot::DealProperties.create_group!(params)
-          expect(Hubspot::DealProperties.same?(response, params)).to be_true
+          expect(Hubspot::DealProperties.same?(response, params)).to be true
         end
       end
 
@@ -213,7 +213,7 @@ describe Hubspot::DealProperties do
         it 'should return the valid parameters' do
           params['name'] = 'ff_group234'
           response       = Hubspot::DealProperties.create_group!(sub_params)
-          expect(Hubspot::DealProperties.same?(response, sub_params)).to be_true
+          expect(Hubspot::DealProperties.same?(response, sub_params)).to be true
         end
       end
     end
@@ -233,7 +233,7 @@ describe Hubspot::DealProperties do
           params['displayName'] = 'Test Group OneA'
 
           response = Hubspot::DealProperties.update_group!(params['name'], params)
-          expect(Hubspot::DealProperties.same?(response, params)).to be_true
+          expect(Hubspot::DealProperties.same?(response, params)).to be true
         end
       end
 

--- a/spec/lib/hubspot/deal_spec.rb
+++ b/spec/lib/hubspot/deal_spec.rb
@@ -82,19 +82,17 @@ describe Hubspot::Deal do
     end
   end
 
-  describe '#destroy!' do
-    cassette 'destroy_deal'
+  describe "#destroy!" do
+    it "should remove from hubspot" do
+      VCR.use_cassette("destroy_deal") do
+        deal = Hubspot::Deal.create!(portal_id, [company_id], [vid], {amount: amount})
 
-    let(:deal) {Hubspot::Deal.create!(portal_id, [company_id], [vid], {amount: amount})}
+        result = deal.destroy!
 
-    it 'should remove from hubspot' do
-      pending
-      expect(Hubspot::Deal.find(deal.deal_id)).to_not be_nil
+        assert_requested :delete, hubspot_api_url("/deals/v1/deal/#{deal.deal_id}?hapikey=demo")
 
-      expect(deal.destroy!).to be_true
-      expect(deal.destroyed?).to be_true
-
-      expect(Hubspot::Deal.find(deal.deal_id)).to be_nil
+        expect(result).to be true
+      end
     end
   end
 

--- a/spec/lib/hubspot/engagement_spec.rb
+++ b/spec/lib/hubspot/engagement_spec.rb
@@ -46,7 +46,7 @@ describe Hubspot::Engagement do
       it 'must find by company id' do
         find_engagements = Hubspot::EngagementNote.find_by_company(engagement.associations["companyIds"].first)
         find_engagements.should_not be_nil
-        find_engagements.any?{|engagement| engagement.id == engagement.id and engagement.body == engagement.body}.should be_true
+        find_engagements.any?{|engagement| engagement.id == engagement.id and engagement.body == engagement.body}.should be true
       end
     end
 
@@ -57,7 +57,7 @@ describe Hubspot::Engagement do
       it 'must find by contact id' do
         find_engagements = Hubspot::EngagementNote.find_by_contact(engagement.associations["contactIds"].first)
         find_engagements.should_not be_nil
-        find_engagements.any?{|engagement| engagement.id == engagement.id and engagement.body == engagement.body}.should be_true
+        find_engagements.any?{|engagement| engagement.id == engagement.id and engagement.body == engagement.body}.should be true
       end
     end
 
@@ -93,8 +93,8 @@ describe Hubspot::Engagement do
       it 'should remove from hubspot' do
         expect(Hubspot::Engagement.find(engagement.id)).to_not be_nil
 
-        expect(engagement.destroy!).to be_true
-        expect(engagement.destroyed?).to be_true
+        expect(engagement.destroy!).to be true
+        expect(engagement.destroyed?).to be true
 
         expect(Hubspot::Engagement.find(engagement.id)).to be_nil
       end
@@ -135,8 +135,8 @@ describe Hubspot::Engagement do
       it 'should remove from hubspot' do
         expect(Hubspot::Engagement.find(engagement.id)).to_not be_nil
 
-        expect(engagement.destroy!).to be_true
-        expect(engagement.destroyed?).to be_true
+        expect(engagement.destroy!).to be true
+        expect(engagement.destroyed?).to be true
 
         expect(Hubspot::Engagement.find(engagement.id)).to be_nil
       end

--- a/spec/lib/hubspot/form_spec.rb
+++ b/spec/lib/hubspot/form_spec.rb
@@ -179,11 +179,11 @@ describe Hubspot::Form do
     # NOTE: form previous created via the create! method
     let(:form) { Hubspot::Form.find('beb92950-ca65-4daf-87ae-a42c054e429f') }
     subject { form.destroy! }
-    it { should be_true }
+    it { should be true }
 
     it 'should be destroyed' do
       subject
-      form.destroyed?.should be_true
+      form.destroyed?.should be true
     end
   end
 end

--- a/spec/lib/hubspot/owner_spec.rb
+++ b/spec/lib/hubspot/owner_spec.rb
@@ -13,7 +13,7 @@ describe Hubspot::Owner do
     it 'should find all owners' do
       owners = Hubspot::Owner.all
 
-      expect(owners.blank?).to be_false
+      expect(owners.blank?).to be false
       compare_owners(owners, example_owners)
     end
   end
@@ -48,7 +48,7 @@ end
 def compare_owners(owners, examples)
   owners.each do |owner|
     example = examples.detect { |o| o['email'] == owner.email }
-    expect(example.blank?).to be_false
+    expect(example.blank?).to be false
     example.each do |key, val|
       expect(owner[key]).to eq(val)
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,7 @@ SimpleCov.start do
 end
 
 require 'rspec'
+require 'rspec/its'
 require 'webmock/rspec'
 require 'hubspot-ruby'
 


### PR DESCRIPTION
Fixes #151 
Fixes #153 

Summary:
Upgrades RSpec to 3.8 and adds the [rspec-its] gem to maintain support
for the `its` style for writing tests.

This PR also:
- updates the deprecated `be_true` and `be_false` to use `be true`
  and `be false`.
- updates/refactors tests that were flagged as pending

[rspec-its]: https://github.com/rspec/rspec-its