### PR TITLE
Fetch gems over https

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 # Add dependencies to hubspot-ruby.gemspec
 gemspec


### PR DESCRIPTION
Summary:
Fetching a gem over http could allow a gem's source code to be
compromised in transit and the source code altered. To avoid any risk,
it's best to always use https.