### PR TITLE
update contact property endpoints

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,3 +1,10 @@
+## 1.0.0 (TBD)
+
+* Updates the endpoints referenced in `ContactProperties` to match the new
+  HubSpot [ContactProperty endpoints].
+
+[ContactProperty endpoints]: https://developers.hubspot.com/docs/methods/contacts/contact-properties-overview
+
 ## 0.6.1 (November 29, 2018)
 
 * [#148] Deprecate the use of the hubspot rake tasks. Deprecating these tasks
@@ -5,7 +12,6 @@
   `Hubspot::Utils.restore_properties`.
 
 [#148]: https://github.com/adimichele/hubspot-ruby/pull/148
-
 
 * [#148] Fix backwards compatibility to ensure users can access the hubspot rake
   tasks

--- a/lib/hubspot/contact_properties.rb
+++ b/lib/hubspot/contact_properties.rb
@@ -1,14 +1,14 @@
 module Hubspot
   class ContactProperties < Properties
 
-    ALL_PROPERTIES_PATH  = '/contacts/v2/properties'
-    ALL_GROUPS_PATH      = '/contacts/v2/groups'
-    CREATE_PROPERTY_PATH = '/contacts/v2/properties/'
-    UPDATE_PROPERTY_PATH = '/contacts/v2/properties/named/:property_name'
-    DELETE_PROPERTY_PATH = '/contacts/v2/properties/named/:property_name'
-    CREATE_GROUP_PATH    = '/contacts/v2/groups/'
-    UPDATE_GROUP_PATH    = '/contacts/v2/groups/named/:group_name'
-    DELETE_GROUP_PATH    = '/contacts/v2/groups/named/:group_name'
+    ALL_PROPERTIES_PATH  = "/properties/v1/contacts/properties"
+    ALL_GROUPS_PATH      = "/properties/v1/contacts/groups"
+    CREATE_PROPERTY_PATH = "/properties/v1/contacts/properties"
+    UPDATE_PROPERTY_PATH = "/properties/v1/contacts/properties/named/:property_name"
+    DELETE_PROPERTY_PATH = "/properties/v1/contacts/properties/named/:property_name"
+    CREATE_GROUP_PATH    = "/properties/v1/contacts/groups"
+    UPDATE_GROUP_PATH    = "/properties/v1/contacts/groups/named/:group_name"
+    DELETE_GROUP_PATH    = "/properties/v1/contacts/groups/named/:group_name"
 
     class << self
       def add_default_parameters(opts={})

--- a/spec/fixtures/vcr_cassettes/contact_properties/all_groups.yml
+++ b/spec/fixtures/vcr_cassettes/contact_properties/all_groups.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.hubapi.com/contacts/v2/groups?hapikey=demo
+    uri: https://api.hubapi.com/properties/v1/contacts/groups?hapikey=demo
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/contact_properties/all_properties.yml
+++ b/spec/fixtures/vcr_cassettes/contact_properties/all_properties.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.hubapi.com/contacts/v2/properties?hapikey=demo
+    uri: https://api.hubapi.com/properties/v1/contacts/properties?hapikey=demo
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/contact_properties/create_group.yml
+++ b/spec/fixtures/vcr_cassettes/contact_properties/create_group.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://api.hubapi.com/contacts/v2/groups/?hapikey=demo
+    uri: https://api.hubapi.com/properties/v1/contacts/groups?hapikey=demo
     body:
       encoding: UTF-8
       string: '{"name":"ff_group1","displayName":"Test Group One","displayOrder":100}'

--- a/spec/fixtures/vcr_cassettes/contact_properties/create_group_some_params.yml
+++ b/spec/fixtures/vcr_cassettes/contact_properties/create_group_some_params.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://api.hubapi.com/contacts/v2/groups/?hapikey=demo
+    uri: https://api.hubapi.com/properties/v1/contacts/groups?hapikey=demo
     body:
       encoding: UTF-8
       string: '{"name":"ff_group234","displayOrder":100}'

--- a/spec/fixtures/vcr_cassettes/contact_properties/create_property.yml
+++ b/spec/fixtures/vcr_cassettes/contact_properties/create_property.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://api.hubapi.com/contacts/v2/properties/?hapikey=demo
+    uri: https://api.hubapi.com/properties/v1/contacts/properties?hapikey=demo
     body:
       encoding: UTF-8
       string: '{"name":"my_new_property","groupName":"contactinformation","description":"What

--- a/spec/fixtures/vcr_cassettes/contact_properties/delete_group.yml
+++ b/spec/fixtures/vcr_cassettes/contact_properties/delete_group.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: delete
-    uri: https://api.hubapi.com/contacts/v2/groups/named/ff_group1?hapikey=demo
+    uri: https://api.hubapi.com/properties/v1/contacts/groups/named/ff_group1?hapikey=demo
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/contact_properties/delete_non_group.yml
+++ b/spec/fixtures/vcr_cassettes/contact_properties/delete_non_group.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: delete
-    uri: https://api.hubapi.com/contacts/v2/groups/named/ff_group1?hapikey=demo
+    uri: https://api.hubapi.com/properties/v1/contacts/groups/named/ff_group1?hapikey=demo
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/contact_properties/delete_non_property.yml
+++ b/spec/fixtures/vcr_cassettes/contact_properties/delete_non_property.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: delete
-    uri: https://api.hubapi.com/contacts/v2/properties/named/my_new_property?hapikey=demo
+    uri: https://api.hubapi.com/properties/v1/contacts/properties/named/my_new_property?hapikey=demo
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/contact_properties/delete_property.yml
+++ b/spec/fixtures/vcr_cassettes/contact_properties/delete_property.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: delete
-    uri: https://api.hubapi.com/contacts/v2/properties/named/my_new_property?hapikey=demo
+    uri: https://api.hubapi.com/properties/v1/contacts/properties/named/my_new_property?hapikey=demo
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/contact_properties/groups_included.yml
+++ b/spec/fixtures/vcr_cassettes/contact_properties/groups_included.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.hubapi.com/contacts/v2/groups?hapikey=demo
+    uri: https://api.hubapi.com/properties/v1/contacts/groups?hapikey=demo
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/contact_properties/groups_not_excluded.yml
+++ b/spec/fixtures/vcr_cassettes/contact_properties/groups_not_excluded.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.hubapi.com/contacts/v2/groups?hapikey=demo
+    uri: https://api.hubapi.com/properties/v1/contacts/groups?hapikey=demo
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/contact_properties/properties_in_groups.yml
+++ b/spec/fixtures/vcr_cassettes/contact_properties/properties_in_groups.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.hubapi.com/contacts/v2/properties?hapikey=demo
+    uri: https://api.hubapi.com/properties/v1/contacts/properties?hapikey=demo
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/contact_properties/properties_not_in_groups.yml
+++ b/spec/fixtures/vcr_cassettes/contact_properties/properties_not_in_groups.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.hubapi.com/contacts/v2/properties?hapikey=demo
+    uri: https://api.hubapi.com/properties/v1/contacts/properties?hapikey=demo
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/contact_properties/update_group.yml
+++ b/spec/fixtures/vcr_cassettes/contact_properties/update_group.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: put
-    uri: https://api.hubapi.com/contacts/v2/groups/named/ff_group1?hapikey=demo
+    uri: https://api.hubapi.com/properties/v1/contacts/groups/named/ff_group1?hapikey=demo
     body:
       encoding: UTF-8
       string: '{"name":"ff_group1","displayName":"Test Group OneA","displayOrder":100}'

--- a/spec/fixtures/vcr_cassettes/contact_properties/update_property.yml
+++ b/spec/fixtures/vcr_cassettes/contact_properties/update_property.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: put
-    uri: https://api.hubapi.com/contacts/v2/properties/named/my_new_property?hapikey=demo
+    uri: https://api.hubapi.com/properties/v1/contacts/properties/named/my_new_property?hapikey=demo
     body:
       encoding: UTF-8
       string: '{"name":"my_new_property","groupName":"contactinformation","description":"What

--- a/spec/fixtures/vcr_cassettes/dump_contact_properties_and_groups.yml
+++ b/spec/fixtures/vcr_cassettes/dump_contact_properties_and_groups.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.hubapi.com/contacts/v2/groups?hapikey=demo
+    uri: https://api.hubapi.com/properties/v1/contacts/groups?hapikey=demo
     body:
       encoding: US-ASCII
       string: ''
@@ -133,7 +133,7 @@ http_interactions:
   recorded_at: Mon, 26 Nov 2018 21:46:19 GMT
 - request:
     method: get
-    uri: https://api.hubapi.com/contacts/v2/properties?hapikey=demo
+    uri: https://api.hubapi.com/properties/v1/contacts/properties?hapikey=demo
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/restore_contact_properties_and_groups.yml
+++ b/spec/fixtures/vcr_cassettes/restore_contact_properties_and_groups.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.hubapi.com/contacts/v2/groups?hapikey=demo
+    uri: https://api.hubapi.com/properties/v1/contacts/groups?hapikey=demo
     body:
       encoding: US-ASCII
       string: ''
@@ -133,7 +133,7 @@ http_interactions:
   recorded_at: Mon, 26 Nov 2018 21:47:12 GMT
 - request:
     method: get
-    uri: https://api.hubapi.com/contacts/v2/properties?hapikey=demo
+    uri: https://api.hubapi.com/properties/v1/contacts/properties?hapikey=demo
     body:
       encoding: US-ASCII
       string: ''
@@ -176,7 +176,7 @@ http_interactions:
   recorded_at: Mon, 26 Nov 2018 21:47:13 GMT
 - request:
     method: get
-    uri: https://api.hubapi.com/contacts/v2/groups?hapikey=demo
+    uri: https://api.hubapi.com/properties/v1/contacts/groups?hapikey=demo
     body:
       encoding: US-ASCII
       string: ''
@@ -307,7 +307,7 @@ http_interactions:
   recorded_at: Mon, 26 Nov 2018 21:47:14 GMT
 - request:
     method: get
-    uri: https://api.hubapi.com/contacts/v2/properties?hapikey=demo
+    uri: https://api.hubapi.com/properties/v1/contacts/properties?hapikey=demo
     body:
       encoding: US-ASCII
       string: ''


### PR DESCRIPTION
Addresses Issue: #164 

Summary:
Updates the endpoints listed in `ContactProperties` to use the new
[HubSpot ContactProperty API endpoints].

The former endpoints still work because HubSpot implemented a redirect
that mapped the old endpoints to hit the new endpoints, resulting in a
response from the new endpoint.

[HubSpot ContactProperty API endpoints]:
https://developers.hubspot.com/docs/methods/contacts/contact-properties-overview