### PR TITLE
update company property endpoints

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,5 +1,10 @@
 ## 1.0.0 (TBD)
 
+* Updates the endpoints referenced in `CompanyProperties` to match the new
+  HubSpot [CompanyProperty endpoints].
+
+[CompanyProperty endpoints]: https://developers.hubspot.com/docs/methods/companies/company-properties-overview
+
 * Updates the endpoints referenced in `ContactProperties` to match the new
   HubSpot [ContactProperty endpoints].
 

--- a/lib/hubspot/company_properties.rb
+++ b/lib/hubspot/company_properties.rb
@@ -1,14 +1,14 @@
 module Hubspot
   class CompanyProperties < Properties
 
-    ALL_PROPERTIES_PATH  = '/companies/v2/properties'
-    ALL_GROUPS_PATH      = '/companies/v2/groups'
-    CREATE_PROPERTY_PATH = '/companies/v2/properties'
-    UPDATE_PROPERTY_PATH = '/companies/v2/properties/named/:property_name'
-    DELETE_PROPERTY_PATH = '/companies/v2/properties/named/:property_name'
-    CREATE_GROUP_PATH    = '/companies/v2/groups'
-    UPDATE_GROUP_PATH    = '/companies/v2/groups/named/:group_name'
-    DELETE_GROUP_PATH    = '/companies/v2/groups/named/:group_name'
+    ALL_PROPERTIES_PATH  = "/properties/v1/companies/properties"
+    ALL_GROUPS_PATH      = "/properties/v1/companies/groups"
+    CREATE_PROPERTY_PATH = "/properties/v1/companies/properties"
+    UPDATE_PROPERTY_PATH = "/properties/v1/companies/properties/named/:property_name"
+    DELETE_PROPERTY_PATH = "/properties/v1/companies/properties/named/:property_name"
+    CREATE_GROUP_PATH    = "/properties/v1/companies/groups"
+    UPDATE_GROUP_PATH    = "/properties/v1/companies/groups/named/:group_name"
+    DELETE_GROUP_PATH    = "/properties/v1/companies/groups/named/:group_name"
 
     class << self
       def add_default_parameters(opts={})

--- a/spec/fixtures/vcr_cassettes/company_find_by_domain.yml
+++ b/spec/fixtures/vcr_cassettes/company_find_by_domain.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.hubapi.com/companies/v2/properties?hapikey=demo
+    uri: https://api.hubapi.com/properties/v1/companies/properties?hapikey=demo
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/company_properties/all_groups.yml
+++ b/spec/fixtures/vcr_cassettes/company_properties/all_groups.yml
@@ -46,7 +46,7 @@ http_interactions:
   recorded_at: Tue, 11 Dec 2018 19:30:25 GMT
 - request:
     method: get
-    uri: https://api.hubapi.com/companies/v2/groups?hapikey=<HAPI_KEY>
+    uri: https://api.hubapi.com/properties/v1/companies/groups?hapikey=<HAPI_KEY>
     body:
       encoding: US-ASCII
       string: ''
@@ -91,7 +91,7 @@ http_interactions:
   recorded_at: Tue, 11 Dec 2018 19:30:25 GMT
 - request:
     method: delete
-    uri: https://api.hubapi.com/companies/v2/groups/named/group_awesome?hapikey=<HAPI_KEY>
+    uri: https://api.hubapi.com/properties/v1/companies/groups/named/group_awesome?hapikey=<HAPI_KEY>
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/company_properties/all_properties.yml
+++ b/spec/fixtures/vcr_cassettes/company_properties/all_properties.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://api.hubapi.com/companies/v2/properties?hapikey=<HAPI_KEY>
+    uri: https://api.hubapi.com/properties/v1/companies/properties?hapikey=<HAPI_KEY>
     body:
       encoding: UTF-8
       string: '{"name":"fax_number","groupName":"companyinformation","description":"The
@@ -48,7 +48,7 @@ http_interactions:
   recorded_at: Tue, 11 Dec 2018 21:12:55 GMT
 - request:
     method: get
-    uri: https://api.hubapi.com/companies/v2/properties?hapikey=<HAPI_KEY>
+    uri: https://api.hubapi.com/properties/v1/companies/properties?hapikey=<HAPI_KEY>
     body:
       encoding: US-ASCII
       string: ''
@@ -422,7 +422,7 @@ http_interactions:
   recorded_at: Tue, 11 Dec 2018 21:12:55 GMT
 - request:
     method: delete
-    uri: https://api.hubapi.com/companies/v2/properties/named/fax_number?hapikey=<HAPI_KEY>
+    uri: https://api.hubapi.com/properties/v1/companies/properties/named/fax_number?hapikey=<HAPI_KEY>
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/company_properties/create_group.yml
+++ b/spec/fixtures/vcr_cassettes/company_properties/create_group.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://api.hubapi.com/companies/v2/groups?hapikey=<HAPI_KEY>
+    uri: https://api.hubapi.com/properties/v1/companies/groups?hapikey=<HAPI_KEY>
     body:
       encoding: UTF-8
       string: '{"name":"ff_group1","displayName":"Test Group One","displayOrder":100}'

--- a/spec/fixtures/vcr_cassettes/company_properties/create_group_some_params.yml
+++ b/spec/fixtures/vcr_cassettes/company_properties/create_group_some_params.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://api.hubapi.com/companies/v2/groups?hapikey=<HAPI_KEY>
+    uri: https://api.hubapi.com/properties/v1/companies/groups?hapikey=<HAPI_KEY>
     body:
       encoding: UTF-8
       string: '{"name":"ff_group235","displayOrder":100}'

--- a/spec/fixtures/vcr_cassettes/company_properties/create_property.yml
+++ b/spec/fixtures/vcr_cassettes/company_properties/create_property.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://api.hubapi.com/companies/v2/properties?hapikey=<HAPI_KEY>
+    uri: https://api.hubapi.com/properties/v1/companies/properties?hapikey=<HAPI_KEY>
     body:
       encoding: UTF-8
       string: '{"name":"fax_number","groupName":"companyinformation","options":[]}'
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Wed, 12 Dec 2018 16:22:23 GMT
 - request:
     method: delete
-    uri: https://api.hubapi.com/companies/v2/properties/named/fax_number?hapikey=<HAPI_KEY>
+    uri: https://api.hubapi.com/properties/v1/companies/properties/named/fax_number?hapikey=<HAPI_KEY>
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/company_properties/delete_group.yml
+++ b/spec/fixtures/vcr_cassettes/company_properties/delete_group.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: delete
-    uri: https://api.hubapi.com/companies/v2/groups/named/ff_group1?hapikey=demo
+    uri: https://api.hubapi.com/properties/v1/companies/groups/named/ff_group1?hapikey=demo
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/company_properties/delete_non_group.yml
+++ b/spec/fixtures/vcr_cassettes/company_properties/delete_non_group.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: delete
-    uri: https://api.hubapi.com/companies/v2/groups/named/ff_group1?hapikey=demo
+    uri: https://api.hubapi.com/properties/v1/companies/groups/named/ff_group1?hapikey=demo
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/company_properties/delete_non_property.yml
+++ b/spec/fixtures/vcr_cassettes/company_properties/delete_non_property.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: delete
-    uri: https://api.hubapi.com/companies/v2/properties/named/non-existent?hapikey=<HAPI_KEY>
+    uri: https://api.hubapi.com/properties/v1/companies/properties/named/non-existent?hapikey=<HAPI_KEY>
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/company_properties/delete_property.yml
+++ b/spec/fixtures/vcr_cassettes/company_properties/delete_property.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://api.hubapi.com/companies/v2/properties?hapikey=<HAPI_KEY>
+    uri: https://api.hubapi.com/properties/v1/companies/properties?hapikey=<HAPI_KEY>
     body:
       encoding: UTF-8
       string: '{"name":"fax_number","groupName":"companyinformation","type":"string","options":[]}'
@@ -46,7 +46,7 @@ http_interactions:
   recorded_at: Wed, 12 Dec 2018 20:06:05 GMT
 - request:
     method: delete
-    uri: https://api.hubapi.com/companies/v2/properties/named/fax_number?hapikey=<HAPI_KEY>
+    uri: https://api.hubapi.com/properties/v1/companies/properties/named/fax_number?hapikey=<HAPI_KEY>
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/company_properties/exclude_by_group.yml
+++ b/spec/fixtures/vcr_cassettes/company_properties/exclude_by_group.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://api.hubapi.com/companies/v2/properties?hapikey=<HAPI_KEY>
+    uri: https://api.hubapi.com/properties/v1/companies/properties?hapikey=<HAPI_KEY>
     body:
       encoding: UTF-8
       string: '{"name":"fax_number","groupName":"companyinformation","description":"The
@@ -48,7 +48,7 @@ http_interactions:
   recorded_at: Tue, 11 Dec 2018 16:13:06 GMT
 - request:
     method: post
-    uri: https://api.hubapi.com/companies/v2/properties?hapikey=<HAPI_KEY>
+    uri: https://api.hubapi.com/properties/v1/companies/properties?hapikey=<HAPI_KEY>
     body:
       encoding: UTF-8
       string: '{"name":"instagram_handle","groupName":"socialmediainformation","description":"The
@@ -95,7 +95,7 @@ http_interactions:
   recorded_at: Tue, 11 Dec 2018 16:13:06 GMT
 - request:
     method: get
-    uri: https://api.hubapi.com/companies/v2/properties?hapikey=<HAPI_KEY>
+    uri: https://api.hubapi.com/properties/v1/companies/properties?hapikey=<HAPI_KEY>
     body:
       encoding: US-ASCII
       string: ''
@@ -470,7 +470,7 @@ http_interactions:
   recorded_at: Tue, 11 Dec 2018 16:13:06 GMT
 - request:
     method: delete
-    uri: https://api.hubapi.com/companies/v2/properties/named/fax_number?hapikey=<HAPI_KEY>
+    uri: https://api.hubapi.com/properties/v1/companies/properties/named/fax_number?hapikey=<HAPI_KEY>
     body:
       encoding: US-ASCII
       string: ''
@@ -506,7 +506,7 @@ http_interactions:
   recorded_at: Tue, 11 Dec 2018 16:13:06 GMT
 - request:
     method: delete
-    uri: https://api.hubapi.com/companies/v2/properties/named/instagram_handle?hapikey=<HAPI_KEY>
+    uri: https://api.hubapi.com/properties/v1/companies/properties/named/instagram_handle?hapikey=<HAPI_KEY>
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/company_properties/filter_by_group.yml
+++ b/spec/fixtures/vcr_cassettes/company_properties/filter_by_group.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://api.hubapi.com/companies/v2/properties?hapikey=<HAPI_KEY>
+    uri: https://api.hubapi.com/properties/v1/companies/properties?hapikey=<HAPI_KEY>
     body:
       encoding: UTF-8
       string: '{"name":"fax_number","groupName":"companyinformation","description":"The
@@ -48,7 +48,7 @@ http_interactions:
   recorded_at: Tue, 11 Dec 2018 16:07:31 GMT
 - request:
     method: post
-    uri: https://api.hubapi.com/companies/v2/properties?hapikey=<HAPI_KEY>
+    uri: https://api.hubapi.com/properties/v1/companies/properties?hapikey=<HAPI_KEY>
     body:
       encoding: UTF-8
       string: '{"name":"instagram_handle","groupName":"socialmediainformation","description":"The
@@ -95,7 +95,7 @@ http_interactions:
   recorded_at: Tue, 11 Dec 2018 16:07:32 GMT
 - request:
     method: get
-    uri: https://api.hubapi.com/companies/v2/properties?hapikey=<HAPI_KEY>
+    uri: https://api.hubapi.com/properties/v1/companies/properties?hapikey=<HAPI_KEY>
     body:
       encoding: US-ASCII
       string: ''
@@ -470,7 +470,7 @@ http_interactions:
   recorded_at: Tue, 11 Dec 2018 16:07:32 GMT
 - request:
     method: delete
-    uri: https://api.hubapi.com/companies/v2/properties/named/fax_number?hapikey=<HAPI_KEY>
+    uri: https://api.hubapi.com/properties/v1/companies/properties/named/fax_number?hapikey=<HAPI_KEY>
     body:
       encoding: US-ASCII
       string: ''
@@ -506,7 +506,7 @@ http_interactions:
   recorded_at: Tue, 11 Dec 2018 16:07:32 GMT
 - request:
     method: delete
-    uri: https://api.hubapi.com/companies/v2/properties/named/instagram_handle?hapikey=<HAPI_KEY>
+    uri: https://api.hubapi.com/properties/v1/companies/properties/named/instagram_handle?hapikey=<HAPI_KEY>
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/company_properties/groups_excluded.yml
+++ b/spec/fixtures/vcr_cassettes/company_properties/groups_excluded.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://api.hubapi.com/companies/v2/properties?hapikey=<HAPI_KEY>
+    uri: https://api.hubapi.com/properties/v1/companies/properties?hapikey=<HAPI_KEY>
     body:
       encoding: UTF-8
       string: '{"name":"instagram_handle","groupName":"socialmediainformation","description":"The
@@ -49,7 +49,7 @@ http_interactions:
   recorded_at: Wed, 12 Dec 2018 20:28:23 GMT
 - request:
     method: post
-    uri: https://api.hubapi.com/companies/v2/properties?hapikey=<HAPI_KEY>
+    uri: https://api.hubapi.com/properties/v1/companies/properties?hapikey=<HAPI_KEY>
     body:
       encoding: UTF-8
       string: '{"name":"fax_number","groupName":"companyinformation","description":"The
@@ -95,7 +95,7 @@ http_interactions:
   recorded_at: Wed, 12 Dec 2018 20:28:24 GMT
 - request:
     method: get
-    uri: https://api.hubapi.com/companies/v2/groups?hapikey=<HAPI_KEY>
+    uri: https://api.hubapi.com/properties/v1/companies/groups?hapikey=<HAPI_KEY>
     body:
       encoding: US-ASCII
       string: ''
@@ -140,7 +140,7 @@ http_interactions:
   recorded_at: Wed, 12 Dec 2018 20:28:24 GMT
 - request:
     method: delete
-    uri: https://api.hubapi.com/companies/v2/properties/named/instagram_handle?hapikey=<HAPI_KEY>
+    uri: https://api.hubapi.com/properties/v1/companies/properties/named/instagram_handle?hapikey=<HAPI_KEY>
     body:
       encoding: US-ASCII
       string: ''
@@ -176,7 +176,7 @@ http_interactions:
   recorded_at: Wed, 12 Dec 2018 20:28:24 GMT
 - request:
     method: delete
-    uri: https://api.hubapi.com/companies/v2/properties/named/fax_number?hapikey=<HAPI_KEY>
+    uri: https://api.hubapi.com/properties/v1/companies/properties/named/fax_number?hapikey=<HAPI_KEY>
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/company_properties/groups_included.yml
+++ b/spec/fixtures/vcr_cassettes/company_properties/groups_included.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://api.hubapi.com/companies/v2/properties?hapikey=<HAPI_KEY>
+    uri: https://api.hubapi.com/properties/v1/companies/properties?hapikey=<HAPI_KEY>
     body:
       encoding: UTF-8
       string: '{"name":"instagram_handle","groupName":"socialmediainformation","description":"The
@@ -49,7 +49,7 @@ http_interactions:
   recorded_at: Wed, 12 Dec 2018 20:22:39 GMT
 - request:
     method: post
-    uri: https://api.hubapi.com/companies/v2/properties?hapikey=<HAPI_KEY>
+    uri: https://api.hubapi.com/properties/v1/companies/properties?hapikey=<HAPI_KEY>
     body:
       encoding: UTF-8
       string: '{"name":"fax_number","groupName":"companyinformation","description":"The
@@ -95,7 +95,7 @@ http_interactions:
   recorded_at: Wed, 12 Dec 2018 20:22:39 GMT
 - request:
     method: get
-    uri: https://api.hubapi.com/companies/v2/groups?hapikey=<HAPI_KEY>
+    uri: https://api.hubapi.com/properties/v1/companies/groups?hapikey=<HAPI_KEY>
     body:
       encoding: US-ASCII
       string: ''
@@ -140,7 +140,7 @@ http_interactions:
   recorded_at: Wed, 12 Dec 2018 20:22:39 GMT
 - request:
     method: delete
-    uri: https://api.hubapi.com/companies/v2/properties/named/instagram_handle?hapikey=<HAPI_KEY>
+    uri: https://api.hubapi.com/properties/v1/companies/properties/named/instagram_handle?hapikey=<HAPI_KEY>
     body:
       encoding: US-ASCII
       string: ''
@@ -176,7 +176,7 @@ http_interactions:
   recorded_at: Wed, 12 Dec 2018 20:22:39 GMT
 - request:
     method: delete
-    uri: https://api.hubapi.com/companies/v2/properties/named/fax_number?hapikey=<HAPI_KEY>
+    uri: https://api.hubapi.com/properties/v1/companies/properties/named/fax_number?hapikey=<HAPI_KEY>
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/fixtures/vcr_cassettes/company_properties/update_group.yml
+++ b/spec/fixtures/vcr_cassettes/company_properties/update_group.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: put
-    uri: https://api.hubapi.com/companies/v2/groups/named/ff_group1?hapikey=demo
+    uri: https://api.hubapi.com/properties/v1/companies/groups/named/ff_group1?hapikey=demo
     body:
       encoding: UTF-8
       string: '{"name":"ff_group1","displayName":"Test Group OneA","displayOrder":100}'

--- a/spec/fixtures/vcr_cassettes/company_properties/update_property.yml
+++ b/spec/fixtures/vcr_cassettes/company_properties/update_property.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://api.hubapi.com/companies/v2/properties?hapikey=<HAPI_KEY>
+    uri: https://api.hubapi.com/properties/v1/companies/properties?hapikey=<HAPI_KEY>
     body:
       encoding: UTF-8
       string: '{"name":"fax_number","groupName":"companyinformation","type":"string","label":"fax
@@ -47,7 +47,7 @@ http_interactions:
   recorded_at: Wed, 12 Dec 2018 19:55:42 GMT
 - request:
     method: put
-    uri: https://api.hubapi.com/companies/v2/properties/named/fax_number?hapikey=<HAPI_KEY>
+    uri: https://api.hubapi.com/properties/v1/companies/properties/named/fax_number?hapikey=<HAPI_KEY>
     body:
       encoding: UTF-8
       string: '{"groupName":"companyinformation","type":"string","label":"new fax
@@ -92,7 +92,7 @@ http_interactions:
   recorded_at: Wed, 12 Dec 2018 19:55:42 GMT
 - request:
     method: delete
-    uri: https://api.hubapi.com/companies/v2/properties/named/fax_number?hapikey=<HAPI_KEY>
+    uri: https://api.hubapi.com/properties/v1/companies/properties/named/fax_number?hapikey=<HAPI_KEY>
     body:
       encoding: US-ASCII
       string: ''

--- a/spec/lib/hubspot/company_properties_spec.rb
+++ b/spec/lib/hubspot/company_properties_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Hubspot::CompanyProperties do
 
         response = Hubspot::CompanyProperties.all
 
-        assert_hubspot_api_request(:get, "/companies/v2/properties")
+        assert_hubspot_api_request(:get, "/properties/v1/companies/properties")
 
         company_property_names = response.map { |property| property["name"] }
         expect(company_property_names).to include("fax_number")
@@ -64,7 +64,7 @@ RSpec.describe Hubspot::CompanyProperties do
 
           response = Hubspot::CompanyProperties.all({}, { include: [group_a] })
 
-          assert_hubspot_api_request(:get, "/companies/v2/properties")
+          assert_hubspot_api_request(:get, "/properties/v1/companies/properties")
 
           group_names = response.map { |property| property["groupName"] }
           expect(group_names).to include(group_a)
@@ -101,7 +101,7 @@ RSpec.describe Hubspot::CompanyProperties do
 
           response = Hubspot::CompanyProperties.all({}, { exclude: [group_a] })
 
-          assert_hubspot_api_request(:get, "/companies/v2/properties")
+          assert_hubspot_api_request(:get, "/properties/v1/companies/properties")
 
           group_names = response.map { |property| property["groupName"] }
           expect(group_names).not_to include(group_a)
@@ -127,7 +127,7 @@ RSpec.describe Hubspot::CompanyProperties do
 
           assert_hubspot_api_request(
             :post,
-            "/companies/v2/properties",
+            "/properties/v1/companies/properties",
             body: {
               name: name,
               groupName: "companyinformation",
@@ -173,7 +173,7 @@ RSpec.describe Hubspot::CompanyProperties do
 
           assert_hubspot_api_request(
             :put,
-            "/companies/v2/properties",
+            "/properties/v1/companies/properties/named",
             body: {
               groupName: "companyinformation",
               label: new_label,
@@ -217,7 +217,7 @@ RSpec.describe Hubspot::CompanyProperties do
 
           assert_hubspot_api_request(
             :delete,
-            "/companies/v2/properties/named/#{name}"
+            "properties/v1/companies/properties/named/#{name}"
           )
 
           expect(response).to be nil
@@ -245,7 +245,7 @@ RSpec.describe Hubspot::CompanyProperties do
 
           response = Hubspot::CompanyProperties.groups
 
-          assert_hubspot_api_request(:get, "/companies/v2/groups")
+          assert_hubspot_api_request(:get, "/properties/v1/companies/groups")
 
           group_names = response.map { |group| group["name"] }
           expect(group_names).to include(group_name)
@@ -282,7 +282,7 @@ RSpec.describe Hubspot::CompanyProperties do
               { include: group_a }
             )
 
-            assert_hubspot_api_request(:get, "/companies/v2/groups")
+            assert_hubspot_api_request(:get, "/properties/v1/companies/groups")
 
             Hubspot::CompanyProperties.delete!("instagram_handle")
             Hubspot::CompanyProperties.delete!("fax_number")
@@ -322,7 +322,7 @@ RSpec.describe Hubspot::CompanyProperties do
               { exclude: group_a }
             )
 
-            assert_hubspot_api_request(:get, "/companies/v2/groups")
+            assert_hubspot_api_request(:get, "/properties/v1/companies/groups")
 
             group_names = response.map { |group| group["name"] }
             expect(group_names).not_to include(group_a)


### PR DESCRIPTION
Addresses Issue #165 

Summary:
Updates the endpoints listed in `CompanyProperties` to use the new
[HubSpot CompanyProperty API] endpoints.

The former endpoints still work because HubSpot implemented a redirect
that mapped the old endpoints to hit the new endpoints, resulting in a
response from the new endpoint.

[HubSpot CompanyProperty API]:
https://developers.hubspot.com/docs/methods/companies/company-properties-overview