### PR TITLE
Define a consistent return value for `update` actions

### DIFF
--- a/lib/hubspot-ruby.rb
+++ b/lib/hubspot-ruby.rb
@@ -21,6 +21,7 @@ require 'hubspot/owner'
 require 'hubspot/engagement'
 require 'hubspot/subscription'
 require 'hubspot/oauth'
+require 'hubspot/response'
 
 module Hubspot
   def self.configure(config={})

--- a/lib/hubspot/company.rb
+++ b/lib/hubspot/company.rb
@@ -151,7 +151,22 @@ module Hubspot
         end
         Hubspot::Connection.post_json(BATCH_UPDATE_PATH, params: {}, body: query)
       end
-    
+
+      # Update a company
+      # {http://developers.hubspot.com/docs/methods/companies/update_company}
+      # @param vid [Integer] hubspot company vid
+      # @param params [Hash] hash of properties to update
+      # @return [Hubspot::Response]
+      def update!(vid, params)
+        properties = Hubspot::Utils.hash_to_properties(params, key_name: "name")
+
+        Hubspot::Connection.put_json(
+          UPDATE_COMPANY_PATH,
+          params: { company_id: vid },
+          body: { "properties" => properties }
+        )
+      end
+
       # Adds contact to a company
       # {http://developers.hubspot.com/docs/methods/companies/add_contact_to_company}
       # @param company_vid [Integer] The ID of a company to add a contact to

--- a/lib/hubspot/company.rb
+++ b/lib/hubspot/company.rb
@@ -180,17 +180,6 @@ module Hubspot
       @properties[property]
     end
 
-    # Updates the properties of a company
-    # {http://developers.hubspot.com/docs/methods/companies/update_company}
-    # @param params [Hash] hash of properties to update
-    # @return [Hubspot::Company] self
-    def update!(params)
-      query = {"properties" => Hubspot::Utils.hash_to_properties(params.stringify_keys!, key_name: "name")}
-      Hubspot::Connection.put_json(UPDATE_COMPANY_PATH, params: { company_id: vid }, body: query)
-      @properties.merge!(params)
-      self
-    end
-
     # Gets ALL contact vids of a company
     # May make many calls if the company has a mega-ton of contacts
     # {http://developers.hubspot.com/docs/methods/companies/get_company_contacts_by_id}

--- a/lib/hubspot/connection.rb
+++ b/lib/hubspot/connection.rb
@@ -7,7 +7,8 @@ module Hubspot
         url = generate_url(path, opts)
         response = get(url, format: :json)
         log_request_and_response url, response
-        handle_response(response)
+        raise(Hubspot::RequestError.new(response)) unless response.success?
+        response.parsed_response
       end
 
       def post_json(path, opts)
@@ -47,7 +48,7 @@ module Hubspot
 
       def handle_response(response)
         if response.success?
-          response.parsed_response
+          Hubspot::Response.new(body: response.parsed_response)
         else
           raise(Hubspot::RequestError.new(response))
         end

--- a/lib/hubspot/response.rb
+++ b/lib/hubspot/response.rb
@@ -1,0 +1,9 @@
+module Hubspot
+  class Response
+    attr_reader :body
+
+    def initialize(body:)
+      @body = body
+    end
+  end
+end

--- a/spec/fixtures/vcr_cassettes/companies/update_company.yml
+++ b/spec/fixtures/vcr_cassettes/companies/update_company.yml
@@ -1,0 +1,156 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.hubapi.com/companies/v2/companies/?hapikey=demo
+    body:
+      encoding: UTF-8
+      string: '{"properties":[{"name":"name","value":"New Company"}]}'
+    headers:
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 20 Dec 2018 04:01:38 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=dccefb37fe3cd5c1c5f81374a3a064f201545278498; expires=Fri, 20-Dec-19
+        04:01:38 GMT; path=/; domain=.hubapi.com; HttpOnly
+      X-Trace:
+      - 2B7AAB92CF8B396E16DCDFF4E1CA527EEB8659217E000000000000000000
+      X-Hubspot-Ratelimit-Daily:
+      - '160000'
+      X-Hubspot-Ratelimit-Daily-Remaining:
+      - '73135'
+      X-Hubspot-Ratelimit-Secondly:
+      - '60'
+      X-Hubspot-Ratelimit-Secondly-Remaining:
+      - '59'
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 48bf3575c9e55a3e-BOS
+    body:
+      encoding: UTF-8
+      string: '{"portalId":62515,"companyId":1119276107,"isDeleted":false,"properties":{"hs_lastmodifieddate":{"value":"1545278498238","timestamp":1545278498238,"source":"CALCULATED","sourceId":null,"versions":[{"name":"hs_lastmodifieddate","value":"1545278498238","timestamp":1545278498238,"source":"CALCULATED","sourceVid":[],"requestId":"a5e704f8-ce0e-4901-9a3d-889ab59e15b8"}]},"name":{"value":"New
+        Company","timestamp":1545278498238,"source":"API","sourceId":null,"versions":[{"name":"name","value":"New
+        Company","timestamp":1545278498238,"source":"API","sourceVid":[],"requestId":"a5e704f8-ce0e-4901-9a3d-889ab59e15b8"}]},"createdate":{"value":"1545278498238","timestamp":1545278498238,"source":"API","sourceId":null,"versions":[{"name":"createdate","value":"1545278498238","timestamp":1545278498238,"source":"API","sourceVid":[],"requestId":"a5e704f8-ce0e-4901-9a3d-889ab59e15b8"},{"name":"createdate","value":"1545278498238","timestamp":1545278498238,"sourceId":"API","source":"API","sourceVid":[],"requestId":"a5e704f8-ce0e-4901-9a3d-889ab59e15b8"}]}},"additionalDomains":[],"stateChanges":[],"mergeAudits":[]}'
+    http_version: 
+  recorded_at: Thu, 20 Dec 2018 04:01:38 GMT
+- request:
+    method: put
+    uri: https://api.hubapi.com/companies/v2/companies/1119276107?hapikey=demo
+    body:
+      encoding: UTF-8
+      string: '{"properties":[{"name":"name","value":"Newer Company"}]}'
+    headers:
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 20 Dec 2018 04:01:38 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d768c32ad459b0405e90dcc38b338c9db1545278498; expires=Fri, 20-Dec-19
+        04:01:38 GMT; path=/; domain=.hubapi.com; HttpOnly
+      X-Trace:
+      - 2BC186E36B38D0319810BC64987E61799C6DAC70EA000000000000000000
+      X-Hubspot-Ratelimit-Daily:
+      - '160000'
+      X-Hubspot-Ratelimit-Daily-Remaining:
+      - '73134'
+      X-Hubspot-Ratelimit-Secondly:
+      - '60'
+      X-Hubspot-Ratelimit-Secondly-Remaining:
+      - '58'
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 48bf35771abd5a4a-BOS
+    body:
+      encoding: UTF-8
+      string: '{"portalId":62515,"companyId":1119276107,"isDeleted":false,"properties":{"hs_lastmodifieddate":{"value":"1545278498450","timestamp":1545278498450,"source":"CALCULATED","sourceId":null,"versions":[{"name":"hs_lastmodifieddate","value":"1545278498450","timestamp":1545278498450,"source":"CALCULATED","sourceVid":[],"requestId":"8c02c13c-6257-4f51-850a-3b55f159f774"},{"name":"hs_lastmodifieddate","value":"1545278498238","timestamp":1545278498238,"source":"CALCULATED","sourceVid":[],"requestId":"a5e704f8-ce0e-4901-9a3d-889ab59e15b8"}]},"name":{"value":"Newer
+        Company","timestamp":1545278498450,"source":"API","sourceId":"8c02c13c-6257-4f51-850a-3b55f159f774","versions":[{"name":"name","value":"Newer
+        Company","timestamp":1545278498450,"sourceId":"8c02c13c-6257-4f51-850a-3b55f159f774","source":"API","sourceVid":[],"requestId":"8c02c13c-6257-4f51-850a-3b55f159f774"},{"name":"name","value":"New
+        Company","timestamp":1545278498238,"source":"API","sourceVid":[],"requestId":"a5e704f8-ce0e-4901-9a3d-889ab59e15b8"}]}},"additionalDomains":[],"stateChanges":[],"mergeAudits":[]}'
+    http_version: 
+  recorded_at: Thu, 20 Dec 2018 04:01:38 GMT
+- request:
+    method: delete
+    uri: https://api.hubapi.com/companies/v2/companies/1119276107?hapikey=demo
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers: {}
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 20 Dec 2018 04:01:38 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - __cfduid=d23eab2aed89e086a4bc387ca6a037bbc1545278498; expires=Fri, 20-Dec-19
+        04:01:38 GMT; path=/; domain=.hubapi.com; HttpOnly
+      X-Trace:
+      - 2BC81AF32F51E726203970DAB2FCBA30F17AA6C7B3000000000000000000
+      X-Hubspot-Ratelimit-Daily:
+      - '160000'
+      X-Hubspot-Ratelimit-Daily-Remaining:
+      - '73133'
+      X-Hubspot-Ratelimit-Secondly:
+      - '60'
+      X-Hubspot-Ratelimit-Secondly-Remaining:
+      - '57'
+      Access-Control-Allow-Credentials:
+      - 'false'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 48bf35784b4bae14-BOS
+    body:
+      encoding: UTF-8
+      string: '{"companyId":1119276107,"deleted":true}'
+    http_version: 
+  recorded_at: Thu, 20 Dec 2018 04:01:38 GMT
+recorded_with: VCR 4.0.0

--- a/spec/lib/hubspot/company_properties_spec.rb
+++ b/spec/lib/hubspot/company_properties_spec.rb
@@ -181,7 +181,8 @@ RSpec.describe Hubspot::CompanyProperties do
               type: "string",
             }
           )
-          expect(response["label"]).to eq(new_label)
+
+          expect(response.body["label"]).to eq(new_label)
 
           Hubspot::CompanyProperties.delete!(name)
         end
@@ -381,7 +382,7 @@ RSpec.describe Hubspot::CompanyProperties do
           params['displayName'] = 'Test Group OneA'
 
           response = Hubspot::CompanyProperties.update_group!(params['name'], params)
-          expect(Hubspot::CompanyProperties.same?(response, params)).to be true
+          expect(Hubspot::CompanyProperties.same?(response.body, params)).to be true
         end
       end
 

--- a/spec/lib/hubspot/company_spec.rb
+++ b/spec/lib/hubspot/company_spec.rb
@@ -179,24 +179,6 @@ describe Hubspot::Contact do
     end
   end
 
-  describe "#update!" do
-    cassette "company_update"
-    let(:company){ Hubspot::Company.new(example_company_hash) }
-    let(:params){ {name: "Acme Cogs", domain: "abccogs.com"} }
-    subject{ company.update!(params) }
-
-    it{ should be_an_instance_of Hubspot::Company }
-    its(["name"]){ should ==  "Acme Cogs" }
-    its(["domain"]){ should ==  "abccogs.com" }
-
-    context "when the request is not successful" do
-      let(:company){ Hubspot::Company.new({"vid" => "invalid", "properties" => {}})}
-      it "raises an error" do
-        expect{ subject }.to raise_error Hubspot::RequestError
-      end
-    end
-  end
-
   describe "#batch_update!" do
     cassette "company_batch_update"
     let(:company){ Hubspot::Company.create!("company_#{Time.now.to_i}@example.com") }

--- a/spec/lib/hubspot/company_spec.rb
+++ b/spec/lib/hubspot/company_spec.rb
@@ -179,6 +179,23 @@ describe Hubspot::Contact do
     end
   end
 
+  describe ".update!" do
+    it "updates the company" do
+      VCR.use_cassette("companies/update_company") do
+        company = Hubspot::Company.create!("New Company")
+
+        Hubspot::Company.update!(company.vid, name: "Newer Company")
+
+        assert_requested(
+          :put,
+          hubspot_api_url("/companies/v2/companies/#{company.vid}?hapikey=demo")
+        )
+
+        company.destroy!
+      end
+    end
+  end
+
   describe "#batch_update!" do
     cassette "company_batch_update"
     let(:company){ Hubspot::Company.create!("company_#{Time.now.to_i}@example.com") }

--- a/spec/lib/hubspot/connection_spec.rb
+++ b/spec/lib/hubspot/connection_spec.rb
@@ -45,7 +45,7 @@ describe Hubspot::Connection do
   end
 
   describe ".put_json" do
-    it "issues a PUT request and returns the parsed body" do
+    it "issues a PUT request and returns a response" do
       path = "/some/path"
       update_options = { params: {}, body: {} }
 
@@ -63,7 +63,7 @@ describe Hubspot::Connection do
          }
       )
 
-      expect(response).to eq({ "vid" => 123 })
+      expect(response.body).to eq({ "vid" => 123 })
     end
 
     it "logs information about the request and response" do

--- a/spec/lib/hubspot/contact_properties_spec.rb
+++ b/spec/lib/hubspot/contact_properties_spec.rb
@@ -105,15 +105,17 @@ describe Hubspot::ContactProperties do
         end
       end
 
-      context 'with mixed parameters' do
-        cassette 'contact_properties/update_property'
+      context "with mixed parameters" do
+        it "should return the valid parameters" do
+          VCR.use_cassette("contact_properties/update_property") do
+            params["description"] = "What is their favorite flavor?"
 
-        it 'should return the valid parameters' do
-          params['description']       = 'What is their favorite flavor?'
-          valid_params['description'] = params['description']
+            response = Hubspot::ContactProperties.update!(params["name"], params)
 
-          response = Hubspot::ContactProperties.update!(params['name'], params)
-          valid_params.each { |k, v| expect(response[k]).to eq(v) }
+            expect(response.body).to include({
+              "description" => "What is their favorite flavor?",
+            })
+          end
         end
       end
     end
@@ -216,7 +218,7 @@ describe Hubspot::ContactProperties do
           params['displayName'] = 'Test Group OneA'
 
           response = Hubspot::ContactProperties.update_group!(params['name'], params)
-          expect(Hubspot::ContactProperties.same?(response, params)).to be true
+          expect(Hubspot::ContactProperties.same?(response.body, params)).to be true
         end
       end
 

--- a/spec/lib/hubspot/deal_properties_spec.rb
+++ b/spec/lib/hubspot/deal_properties_spec.rb
@@ -130,7 +130,7 @@ describe Hubspot::DealProperties do
           params['description'] = 'What is their favorite flavor?'
 
           response = Hubspot::DealProperties.update!(params['name'], params)
-          expect(Hubspot::DealProperties.same?(response, params)).to be true
+          expect(Hubspot::DealProperties.same?(response.body, params)).to be true
         end
       end
     end
@@ -233,7 +233,7 @@ describe Hubspot::DealProperties do
           params['displayName'] = 'Test Group OneA'
 
           response = Hubspot::DealProperties.update_group!(params['name'], params)
-          expect(Hubspot::DealProperties.same?(response, params)).to be true
+          expect(Hubspot::DealProperties.same?(response.body, params)).to be true
         end
       end
 


### PR DESCRIPTION
What does an `update` action return?

Depending on which class you're using, calling `.update!` or `#update!` will vary between returning a hash or an instance of the class.

How can we make this consistent and give our users the best experience?
I'd like to suggest that we always return a `Hubspot::Response` object that contains the parsed JSON
and avoid parsing the HubSpot API response to a domain object, (ex: `Deal`).

My thought process behind this approach:
- We want to return all the fields that are returned by the HubSpot API. I've used API wrappers in the past that limit the fields the gem user could access and it made for a poor user experience.
- Keep the interface simple. Define one class level `.update!` action and remove existing instance `#update!` methods.
- Adding support for new endpoints should be easy. We want maintainers and contributors to enjoy adding to this project, keeping this project useful and up-to-date with the HubSpot API.

If everyone likes this approach, next steps include:
1) Document this change in History.md
1) We can merge this PR as is because the `update` actions that return a class instance are not using the response from `Connection.put_json`
1) Alter the `update` actions that return a class instance to be class level methods that return a `Hubspot::Response`.
1) Apply this approach to `GET`, `POST`, and `DELETE` actions