### PR TITLE
Define a separate method for form submission

### DIFF
--- a/lib/hubspot/form.rb
+++ b/lib/hubspot/form.rb
@@ -63,8 +63,11 @@ module Hubspot
 
     # {https://developers.hubspot.com/docs/methods/forms/submit_form}
     def submit(opts={})
-      response = Hubspot::FormsConnection.submit(SUBMIT_DATA_PATH, params: { form_guid: @guid }, body: opts)
-      [204, 302, 200].include?(response.code)
+      [204, 302, 200].include?(submit_response(opts).code)
+    end
+
+    def submit_response(opts={})
+      Hubspot::FormsConnection.submit(SUBMIT_DATA_PATH, params: { form_guid: @guid }, body: opts)
     end
 
     # {https://developers.hubspot.com/docs/methods/forms/update_form}

--- a/spec/lib/hubspot/form_spec.rb
+++ b/spec/lib/hubspot/form_spec.rb
@@ -156,6 +156,51 @@ describe Hubspot::Form do
     end
   end
 
+  describe '#submit_response' do
+    cassette 'form_submit_data'
+
+    let(:form) { Hubspot::Form.find('561d9ce9-bb4c-45b4-8e32-21cdeaa3a7f0') }
+
+    context 'with a valid portal id' do
+      before do
+        Hubspot.configure(hapikey: 'demo', portal_id: '62515')
+      end
+
+      it 'returns the HTTParty::Response if the form submission is successful' do
+        params = {}
+        result = form.submit_response(params)
+        result.should be_an_instance_of HTTParty::Response
+        result.code.should eq 200
+      end
+    end
+
+    context 'with an invalid portal id' do
+      before do
+        Hubspot.configure(hapikey: 'demo', portal_id: 'xxxx')
+      end
+
+      it 'returns the HTTParty::Response in case of errors' do
+        params = { unknown_field: :bogus_value }
+        result = form.submit_response(params)
+        result.should be_an_instance_of HTTParty::Response
+        result.code.should eq 404
+      end
+    end
+
+    context 'when initializing Hubspot::Form directly' do
+      let(:form) { Hubspot::Form.new('guid' => '561d9ce9-bb4c-45b4-8e32-21cdeaa3a7f0') }
+
+      before { Hubspot.configure(hapikey: 'demo', portal_id: '62515') }
+
+      it 'returns the HTTParty::Response if the form submission is successful' do
+        params = {}
+        result = form.submit_response(params)
+        result.should be_an_instance_of HTTParty::Response
+        result.code.should eq 200
+      end
+    end
+  end
+
   describe '#update!' do
     cassette 'form_update'
 


### PR DESCRIPTION
The `Hubspot::Form#submit` method only returns boolean values.
True for successful submission and false for an unsuccessful  submission.

It is useful however to be able to view the actual `HTTParty::Response` object directly in order to get more information in case of submission failure.

Therefore i extracted the actual form submission into a separate public method that returns the `HTTParty::Response` object itself.
This change does not modify existing functionality in any way.