### PR TITLE
bump version number to 0.7.0

### DIFF
--- a/hubspot-ruby.gemspec
+++ b/hubspot-ruby.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "hubspot-ruby"
-  s.version = "0.6.1"
+  s.version = "0.7.0"
   s.require_paths = ["lib"]
   s.authors = ["Andrew DiMichele", "Chris Bisnett"]
   s.description = "hubspot-ruby is a wrapper for the HubSpot REST API"


### PR DESCRIPTION
Did you guys release a new version by mistake?

https://rubygems.org/gems/hubspot-ruby lists the version 0.7.0 now
<img width="719" alt="Bildschirmfoto 2019-03-14 um 12 03 00" src="https://user-images.githubusercontent.com/1636511/54352109-29420a80-4651-11e9-986e-8826edc3da3c.png">

If this was not by mistake, this will fix the version number in the `hubspot-ruby.gemspec` file.