### PR TITLE
Add license to gemspec

### DIFF
--- a/hubspot-ruby.gemspec
+++ b/hubspot-ruby.gemspec
@@ -4,6 +4,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.authors = ["Andrew DiMichele", "Chris Bisnett"]
   s.description = "hubspot-ruby is a wrapper for the HubSpot REST API"
+  s.licenses = ["MIT"]
   s.files = [".rspec", "Gemfile", "Guardfile", "LICENSE.txt", "README.md", "RELEASING.md", "Rakefile", "hubspot-ruby.gemspec"]
   s.files += Dir["lib/**/*.rb"]
   s.files += Dir["lib/**/*.rake"]


### PR DESCRIPTION
Following the specifications here: https://guides.rubygems.org/specification-reference/#licenses=

This allows `hubspot-ruby` to play well with license checkers like https://github.com/newrelic/papers and also RubyGems to recognize licensing status.

Currently, it shows as N/A:
![Screen Shot 2019-03-20 at 10 14 47 AM](https://user-images.githubusercontent.com/6193290/54654414-15872000-4af9-11e9-8307-1ddef5c2e5a3.png)
