### PR TITLE
Enable 'since' option for get_companies_modified

### DIFF
--- a/lib/hubspot/company.rb
+++ b/lib/hubspot/company.rb
@@ -70,7 +70,7 @@ class Hubspot::Company < Hubspot::Resource
       Hubspot::PagedCollection.new(opts) do |options, offset, limit|
         response = Hubspot::Connection.get_json(
           RECENTLY_MODIFIED_PATH,
-          {offset: offset, count: limit}
+          options.merge(offset: offset, limit: limit)
         )
 
         companies = response["results"].map { |result| from_result(result) }


### PR DESCRIPTION
Merge additional options to enable 'since" filter for filtering by time providing unix timestamp with ticks (13 digits)
Reference ->https://legacydocs.hubspot.com/docs/methods/companies/get_companies_modified
No additional specs needed IMO, `PagedCollection` covers additional options
