### PR TITLE
Make configuration thread safe

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -25,9 +25,11 @@ jobs:
         ruby-version: ['3.1', '3.0', '2.7']
 
     steps:
+      - name: Install psych 5.0.0 libraries
+        run: sudo apt install haveged libyaml-dev
       - uses: actions/checkout@v3
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@359bebbc29cbe6c87da6bc9ea3bc930432750108
         with:
           ruby-version: ${{ matrix.ruby-version }}
       - name: Install dependencies

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,36 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# GitHub recommends pinning actions to a commit SHA.
+# To get a newer version, you will need to update the SHA.
+# You can also reference a tag or branch, but the action may change without warning.
+
+name: Ruby
+
+on:
+  push:
+    branches: [ 'master', 'main' ]
+  pull_request:
+    branches: [ 'master', 'main' ]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        ruby-version: ['3.1', '3.0', '2.7']
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+      - name: Install dependencies
+        run: bundle install
+      - name: Run tests
+        run: bundle exec rspec

--- a/hubspot-ruby.gemspec
+++ b/hubspot-ruby.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency("timecop")
   s.add_development_dependency("guard-rspec")
   s.add_development_dependency("byebug")
-  s.add_development_dependency("faker")
+  s.add_development_dependency("faker", "> 2.7")
   s.add_development_dependency("factory_bot")
 end
 

--- a/hubspot-ruby.gemspec
+++ b/hubspot-ruby.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency("webmock")
   s.add_development_dependency("vcr")
   s.add_development_dependency("rdoc")
+  s.add_development_dependency("psych")
   s.add_development_dependency("bundler")
   s.add_development_dependency("simplecov")
   s.add_development_dependency("awesome_print")

--- a/lib/hubspot/config.rb
+++ b/lib/hubspot/config.rb
@@ -11,20 +11,33 @@ module Hubspot
     DEFAULT_BASE_URL = "https://api.hubapi.com".freeze
 
     class << self
-      attr_accessor *CONFIG_KEYS
+      attr_reader :default_config
 
+      CONFIG_KEYS.each do |key|
+        namespaced_key = "hubspot-ruby-#{key}"
+
+        define_method key do
+          Thread.current[namespaced_key] || @default_config.try(:[], key.to_s)
+        end
+
+        define_method "#{key}=" do |value|
+          Thread.current[namespaced_key] = value
+        end
+      end
+
+      # @default_config stores the 'original' configuration so we don't have
+      # to reconfigure in every thread, effectively allow inherited configs from a parent thread.
+      #
+      # When changing configuration via threads, @default_config will not
+      # change without calling reset! first. This allows us to use the setter methods or .configure
+      # within threads w/o changing the default state.
       def configure(config)
         config.stringify_keys!
-        @hapikey = config["hapikey"]
-        @base_url = config["base_url"] || DEFAULT_BASE_URL
-        @portal_id = config["portal_id"]
-        @logger = config["logger"] || DEFAULT_LOGGER
-        @access_token = config["access_token"]
-        @client_id = config["client_id"] if config["client_id"].present?
-        @client_secret = config["client_secret"] if config["client_secret"].present?
-        @redirect_uri = config["redirect_uri"] if config["redirect_uri"].present?
-        @read_timeout = config['read_timeout'] || config['timeout']
-        @open_timeout = config['open_timeout'] || config['timeout']
+        @default_config = config if @default_config.nil? # Prevent overwriting default_config w/o calling reset!
+
+        config.each do |key, value|
+          send("#{key}=", value)
+        end
 
         unless authentication_uncertain?
           raise Hubspot::ConfigurationError.new("You must provide either an access_token or an hapikey")
@@ -37,17 +50,19 @@ module Hubspot
       end
 
       def reset!
-        @hapikey = nil
-        @base_url = DEFAULT_BASE_URL
-        @portal_id = nil
-        @logger = DEFAULT_LOGGER
-        @access_token = nil
+        @default_config = nil
+
+        self.hapikey = nil
+        self.base_url = DEFAULT_BASE_URL
+        self.portal_id = nil
+        self.logger = DEFAULT_LOGGER
+        self.access_token = nil
         Hubspot::Connection.headers({})
       end
 
       def ensure!(*params)
         params.each do |p|
-          raise Hubspot::ConfigurationError.new("'#{p}' not configured") unless instance_variable_get "@#{p}"
+          raise Hubspot::ConfigurationError.new("'#{p}' not configured") unless send(p)
         end
       end
 

--- a/lib/hubspot/config.rb
+++ b/lib/hubspot/config.rb
@@ -16,12 +16,16 @@ module Hubspot
       CONFIG_KEYS.each do |key|
         namespaced_key = "hubspot-ruby-#{key}"
 
-        define_method key do
-          Thread.current[namespaced_key] || @default_config.try(:[], key.to_s)
+        unless respond_to?(key)
+          define_method key do
+            Thread.current[namespaced_key] || @default_config.try(:[], key.to_s)
+          end
         end
 
-        define_method "#{key}=" do |value|
-          Thread.current[namespaced_key] = value
+        unless respond_to?("#{key}=")
+          define_method "#{key}=" do |value|
+            Thread.current[namespaced_key] = value
+          end
         end
       end
 

--- a/spec/factories/contacts.rb
+++ b/spec/factories/contacts.rb
@@ -5,6 +5,6 @@ FactoryBot.define do
 
     firstname { Faker::Name.first_name }
     lastname { Faker::Name.last_name }
-    email { Faker::Internet.safe_email("#{Time.new.to_i.to_s[-5..-1]}#{(0..3).map { (65 + rand(26)).chr }.join}") }
+    email { Faker::Internet.safe_email(name: "#{Time.new.to_i.to_s[-5..-1]}#{(0..3).map { (65 + rand(26)).chr }.join}") }
   end
 end

--- a/spec/lib/hubspot/config_spec.rb
+++ b/spec/lib/hubspot/config_spec.rb
@@ -3,38 +3,46 @@ describe Hubspot::Config do
     it "sets the hapikey config" do
       hapikey = "demo"
 
-      config = Hubspot::Config.configure(hapikey: hapikey)
+      Hubspot::Config.configure(hapikey: hapikey)
 
-      expect(config.hapikey).to eq(hapikey)
+      expect(Hubspot::Config.hapikey).to eq(hapikey)
     end
 
     it "changes the base_url" do
       base_url = "https://api.hubapi.com/v2"
 
-      config = Hubspot::Config.configure(
+      Hubspot::Config.configure(
         hapikey: "123abc",
         base_url: base_url
       )
 
-      expect(config.base_url).to eq(base_url)
+      expect(Hubspot::Config.base_url).to eq(base_url)
     end
 
     it "sets a default value for base_url" do
-      config = Hubspot::Config.configure(hapikey: "123abc")
+      Hubspot::Config.configure(hapikey: "123abc")
 
-      expect(config.base_url).to eq("https://api.hubapi.com")
+      expect(Hubspot::Config.base_url).to eq("https://api.hubapi.com")
     end
 
     it "sets a value for portal_id" do
       portal_id = "62515"
 
-      config = Hubspot::Config.configure(
+      Hubspot::Config.configure(
         hapikey: "123abc",
         portal_id: portal_id
       )
 
-      expect(config.portal_id).to eq(portal_id)
+      expect(Hubspot::Config.portal_id).to eq(portal_id)
     end
+
+    it "augments the default_headers when an access_token is provided" do
+      Hubspot::Config.configure(access_token: "123abc")
+
+      expect(Hubspot::Config.access_token).to eq("123abc")
+      expect(Hubspot::Config.default_headers).to eq("Authorization" => "Bearer 123abc")
+    end
+
 
     it "raises when an authentication approach is not provided" do
       expect {

--- a/spec/lib/hubspot/contact_spec.rb
+++ b/spec/lib/hubspot/contact_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Hubspot::Contact do
     context 'without properties' do
       cassette
 
-      let(:email) { Faker::Internet.safe_email("#{(0..3).map { (65 + rand(26)).chr }.join}#{Time.new.to_i.to_s[-5..-1]}") }
+      let(:email) { Faker::Internet.safe_email(name: "#{(0..3).map { (65 + rand(26)).chr }.join}#{Time.new.to_i.to_s[-5..-1]}") }
       subject { described_class.create email }
 
       it 'creates a new contact' do
@@ -56,7 +56,7 @@ RSpec.describe Hubspot::Contact do
     context 'with properties' do
       cassette
 
-      let(:email) { Faker::Internet.safe_email("#{(0..3).map { (65 + rand(26)).chr }.join}#{Time.new.to_i.to_s[-5..-1]}") }
+      let(:email) { Faker::Internet.safe_email(name: "#{(0..3).map { (65 + rand(26)).chr }.join}#{Time.new.to_i.to_s[-5..-1]}") }
       let(:firstname) { "Allison" }
       let(:properties) { { firstname: firstname } }
 


### PR DESCRIPTION
This gem is not thread safe due to how configs and authorization headers are stored.

+ Move config storage to thread-local variables
+ Add a mutex around HTTParty header mutation, restoring original values after mutation.

Based on #238 and #237